### PR TITLE
Use individual temporary Space for each scenario

### DIFF
--- a/functional-tests/src/test/java/com/thoughtworks/gauge/test/common/GaugeProject.java
+++ b/functional-tests/src/test/java/com/thoughtworks/gauge/test/common/GaugeProject.java
@@ -4,6 +4,7 @@ import com.thoughtworks.gauge.Table;
 import com.thoughtworks.gauge.TableRow;
 import com.thoughtworks.gauge.datastore.ScenarioDataStore;
 import com.thoughtworks.gauge.test.StepImpl;
+import com.thoughtworks.gauge.test.confluence.Confluence;
 import com.thoughtworks.gauge.test.git.Config.GitConfig;
 
 import org.apache.commons.io.FileUtils;
@@ -199,10 +200,16 @@ public abstract class GaugeProject {
     }
 
     public ExecutionSummary publishConfluenceDocumentation() throws Exception {
-        return publishConfluenceDocumentation(Map.of());
+        return publishConfluenceDocumentation(new HashMap<String, String>());
     }
 
-    public ExecutionSummary publishConfluenceDocumentation(String[] args, Map<String, String> envVars) throws Exception {
+    /*
+     * Each Gauge scenario in our functional tests gets its own Confluence Space, to
+     * make sure our functional tests can run independently.
+     */
+    public ExecutionSummary publishConfluenceDocumentation(String[] args, Map<String, String> envVars)
+            throws Exception {
+        envVars.put("CONFLUENCE_SPACE_KEY", (String) Confluence.getScenarioSpaceKey());
         boolean success = executeGaugeCommand(args, envVars);
         return new ExecutionSummary(String.join(" ", args), success, lastProcessStdout, lastProcessStderr);
     }
@@ -221,7 +228,7 @@ public abstract class GaugeProject {
     }
 
     public ExecutionSummary publishConfluenceDocumentation(String[] args) throws Exception {
-        return publishConfluenceDocumentation(args, Map.of());
+        return publishConfluenceDocumentation(args, new HashMap<String, String>());
     }
 
     private boolean executeGaugeCommand(String[] args, Map<String, String> envVars)

--- a/functional-tests/src/test/java/com/thoughtworks/gauge/test/confluence/Confluence.java
+++ b/functional-tests/src/test/java/com/thoughtworks/gauge/test/confluence/Confluence.java
@@ -1,0 +1,33 @@
+package com.thoughtworks.gauge.test.confluence;
+
+import com.thoughtworks.gauge.BeforeScenario;
+import com.thoughtworks.gauge.AfterScenario;
+import com.thoughtworks.gauge.datastore.ScenarioDataStore;
+
+import java.time.Instant;
+
+public class Confluence {
+
+    private static final String SCENARIO_SPACE_KEY_NAME = "confluence-space-key";
+    private static final String SCENARIO_SPACE_NAME = "Temporary Gauge Scenario Space";
+
+    public static String getScenarioSpaceKey() {
+        return (String) ScenarioDataStore.get(SCENARIO_SPACE_KEY_NAME);
+    }
+
+    @BeforeScenario
+    public void BeforeScenario() {
+        ScenarioDataStore.put(SCENARIO_SPACE_KEY_NAME, currentTimeInMilliseconds());
+        ConfluenceClient.createSpace(getScenarioSpaceKey(), SCENARIO_SPACE_NAME);
+    }
+
+    @AfterScenario
+    public void AfterScenario() {
+        ConfluenceClient.deleteSpace(getScenarioSpaceKey());
+    }
+
+    public String currentTimeInMilliseconds() {
+        return String.valueOf(Instant.now().toEpochMilli());
+    }
+
+}

--- a/functional-tests/src/test/java/com/thoughtworks/gauge/test/confluence/ConfluenceClient.java
+++ b/functional-tests/src/test/java/com/thoughtworks/gauge/test/confluence/ConfluenceClient.java
@@ -1,0 +1,86 @@
+package com.thoughtworks.gauge.test.confluence;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.util.Base64;
+
+import org.apache.commons.lang3.StringUtils;
+
+import org.json.JSONObject;
+
+public class ConfluenceClient {
+
+    public static void createSpace(String spaceKey, String spaceName) {
+        sendConfluenceRequest(createSpaceRequest(spaceKey, spaceName));
+    }
+
+    public static void deleteSpace(String spaceKey) {
+        sendConfluenceRequest(deleteSpaceRequest(spaceKey));
+    }
+
+    private static HttpRequest createSpaceRequest(String spaceKey, String spaceName) {
+        JSONObject description = new JSONObject().put("plain",
+                new JSONObject().put("value", spaceName).put("representation", "plain"));
+        JSONObject body = new JSONObject().put("key", spaceKey).put("name", spaceName).put("description", description);
+        HttpRequest.Builder builder = baseConfluenceRequest();
+        builder.uri(URI.create(baseSpaceAPIURL()));
+        builder.POST(BodyPublishers.ofString(body.toString()));
+        return builder.build();
+    }
+
+    private static HttpRequest deleteSpaceRequest(String spaceKey) {
+        HttpRequest.Builder builder = baseConfluenceRequest();
+        String deleteSpaceURL = String.format("%1$s/%2$s", baseSpaceAPIURL(), spaceKey);
+        builder.uri(URI.create(deleteSpaceURL));
+        builder.DELETE();
+        return builder.build();
+    }
+
+    private static void sendConfluenceRequest(HttpRequest request) {
+        HttpClient client = HttpClient.newBuilder().version(HttpClient.Version.HTTP_1_1).build();
+        try {
+            verifySuccessfulResponse(client.send(request, HttpResponse.BodyHandlers.ofString()));
+        } catch (IOException | InterruptedException e) {
+            throw new IllegalStateException("Exception when sending Confluence space request", e);
+        }
+    }
+
+    private static void verifySuccessfulResponse(HttpResponse<String> response) {
+        if (response.statusCode() > 299) {
+            String message = String.format("Expected 2xx response but got %1$s. Response body: %2$s",
+                    response.statusCode(), response.body());
+            throw new IllegalStateException(message);
+        }
+    }
+
+    private static HttpRequest.Builder baseConfluenceRequest() {
+        String confluenceUsername = System.getenv("CONFLUENCE_USERNAME");
+        String confluenceToken = System.getenv("CONFLUENCE_TOKEN");
+        return HttpRequest.newBuilder().header("Content-Type", "application/json").header("Authorization",
+                basicAuth(confluenceUsername, confluenceToken));
+    }
+
+    private static String baseSpaceAPIURL() {
+        return String.format("%1$s/rest/api/space", confluenceBaseURL());
+    }
+
+    private static String basicAuth(String username, String password) {
+        return "Basic " + Base64.getEncoder().encodeToString((username + ":" + password).getBytes());
+    }
+
+    private static String confluenceBaseURL() {
+        String baseURL = System.getenv("CONFLUENCE_BASE_URL");
+        if (baseURL.endsWith("/")) {
+            baseURL = StringUtils.chop(baseURL);
+        }
+        if (baseURL.endsWith("atlassian.net")) {
+            return String.format("%1$s/wiki", baseURL);
+        }
+        return baseURL;
+    }
+
+}

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "confluence",
-    "version": "0.1.0",
+    "version": "0.2.0",
     "name": "Confluence",
     "description": "Publishes Gauge specifications to Confluence",
     "install": {


### PR DESCRIPTION
This commit sets up and tears down a new [Confluence Space][1] for each
individual Gauge scenario.  This is very useful as it means there is no
danger of a scenario overwriting another scenario's published specs in
Confluence, thereby causing difficult to diagnose intermittent test
failures.

The implementation (for the scenario-scoped Confluence spaces) uses
the very handy [Gauge Data Store][2] functionality.

[1]: https://support.atlassian.com/confluence-cloud/docs/use-spaces-to-organize-your-work/
[2]: https://docs.gauge.org/writing-specifications.html#data-store