### PR TITLE
Run CI tests against Confluence Server too

### DIFF
--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -41,12 +41,16 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        confluence-version: [Cloud]
+        confluence-version: [Cloud, Server]
         include:
           - confluence-version: Cloud
             confluence-base-url: CONFLUENCE_CLOUD_BASE_URL
             confluence-username: CONFLUENCE_CLOUD_USERNAME
             confluence-token: CONFLUENCE_CLOUD_TOKEN
+          - confluence-version: Server
+            confluence-base-url: CONFLUENCE_SERVER_BASE_URL
+            confluence-username: CONFLUENCE_SERVER_USERNAME
+            confluence-token: CONFLUENCE_SERVER_TOKEN
 
     steps:
       - name: Set up Go 1.15

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "confluence",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "name": "Confluence",
     "description": "Publishes Gauge specifications to Confluence",
     "install": {


### PR DESCRIPTION
Prior to this commit the CI tests were only running against Confluence
Cloud.