### PR TITLE
Add spec with helper functions to manage Space

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ gradle-app.setting
 
 # # Work around https://youtrack.jetbrains.com/issue/IDEA-116898
 # gradle/wrapper/gradle-wrapper.properties
+
+# local properties
+local.properties

--- a/functional-tests/scripts/manage_space.spec
+++ b/functional-tests/scripts/manage_space.spec
@@ -1,0 +1,10 @@
+# Space manager
+
+These specs are just helper functions - they do not document or exercise the Gauge Confluence plugin's functionality.
+
+## Delete the space
+* Delete space
+
+## Create the space
+* Create space
+

--- a/functional-tests/src/test/java/com/thoughtworks/gauge/test/confluence/SpaceManager.java
+++ b/functional-tests/src/test/java/com/thoughtworks/gauge/test/confluence/SpaceManager.java
@@ -1,0 +1,23 @@
+package com.thoughtworks.gauge.test.confluence;
+
+import com.thoughtworks.gauge.Step;
+
+public class SpaceManager {
+
+    @Step("Delete space")
+    public void deleteSpace() {
+        ConfluenceClient.deleteSpace(spaceKey());
+        System.out.println("Deleted space: " + spaceKey());
+    }
+
+    @Step("Create space")
+    public void createSpace() {
+        ConfluenceClient.createSpace(spaceKey(), spaceKey());
+        System.out.println("Deleted space: " + spaceKey());
+    }
+
+    private String spaceKey() {
+        return System.getenv("CONFLUENCE_SPACE_KEY");
+    }
+
+}

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "confluence",
-    "version": "0.4.1",
+    "version": "0.4.2",
     "name": "Confluence",
     "description": "Publishes Gauge specifications to Confluence",
     "install": {


### PR DESCRIPTION
The spec just contains helper functions - they do not document or
exercise the Gauge Confluence plugin's functionality.

For that reason the spec is in a separate `scripts` directory so that
it is not run with the normal specs.