### PR TITLE
Do not publish if space has been manually edited

### DIFF
--- a/.github/workflows/check-commit-message.yml
+++ b/.github/workflows/check-commit-message.yml
@@ -21,5 +21,5 @@ jobs:
         uses: mristin/opinionated-commit-message@v2.2.0
         with:
           allow-one-liners: 'true'
-          additional-verbs: 'export, parse, append, skip, store'
+          additional-verbs: 'export, parse, append, skip, store, retry'
 

--- a/functional-tests/specs/check_config_vars.spec
+++ b/functional-tests/specs/check_config_vars.spec
@@ -12,6 +12,6 @@
 * Required configuration variable <config variable> must be set
 
 
-______________________________________________________________________________
+________________________________________________________________________________________________
 
 Read more about [Gauge's configuration documentation](https://docs.gauge.org/configuration.html)

--- a/functional-tests/specs/space_validity.spec
+++ b/functional-tests/specs/space_validity.spec
@@ -1,0 +1,33 @@
+# Confluence Space validity
+
+## Publishing is aborted if the Space has been manually edited since the last publish
+This Gauge Confluence plugin requires that the specs for a given Gauge project are published to
+their own dedicated [Confluence Space][1], with no manual edits or additions in Confluence.
+Having the Space only contain published Gauge specs ensures that there is no danger of the plugin
+inadvertently overwriting or deleting manually created Confluence pages.
+NB The specs can still be appear alongside your existing manually created Confluence documentation
+in other spaces, by using Confluence's [Include Page macro][2].  This macro
+[allows you to include the full page tree of specs in as many other spaces as you like][3].
+
+* Publish specs to Confluence:
+
+   |heading|
+   |-------|
+   |A spec |
+
+* Manually add a page to the Confluence space
+
+* Publish specs to Confluence:
+
+   |heading     |
+   |------------|
+   |Another spec|
+
+* The error message "Failed: the space has been modified since the last publish" should be output
+
+
+__________________________________________________________________________________________
+
+[1]: https://support.atlassian.com/confluence-cloud/docs/use-spaces-to-organize-your-work/
+[2]: https://support.atlassian.com/confluence-cloud/docs/insert-the-include-page-macro/
+[3]: https://community.atlassian.com/t5/Confluence-questions/How-do-create-cross-space-navigation-sidebar/qaq-p/441031

--- a/functional-tests/specs/space_validity.spec
+++ b/functional-tests/specs/space_validity.spec
@@ -5,7 +5,7 @@ This Gauge Confluence plugin requires that the specs for a given Gauge project a
 their own dedicated [Confluence Space][1], with no manual edits or additions in Confluence.
 Having the Space only contain published Gauge specs ensures that there is no danger of the plugin
 inadvertently overwriting or deleting manually created Confluence pages.
-NB The specs can still be appear alongside your existing manually created Confluence documentation
+NB The specs can still appear alongside your existing manually created Confluence documentation
 in other spaces, by using Confluence's [Include Page macro][2].  This macro
 [allows you to include the full page tree of specs in as many other spaces as you like][3].
 

--- a/functional-tests/src/test/java/com/thoughtworks/gauge/test/confluence/Confluence.java
+++ b/functional-tests/src/test/java/com/thoughtworks/gauge/test/confluence/Confluence.java
@@ -12,6 +12,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.time.Instant;
+import java.time.LocalTime;
+import java.util.concurrent.TimeUnit;
 
 public class Confluence {
 
@@ -52,6 +54,18 @@ public class Confluence {
     private void assertConsoleSuccessOutput(int totalPages) throws IOException {
         new Console().outputContains(
                 String.format("Success: published %d specs and directory pages to Confluence", totalPages));
+    }
+
+    @Step("Manually add a page to the Confluence space")
+    public void manuallyAddPageToConfluenceSpace() throws InterruptedException {
+        // the page needs to be added at a later minute than when the last publish ran
+        waitForNextMinuteToStart();
+        ConfluenceClient.createPage(getScenarioSpaceKey());
+        TimeUnit.SECONDS.sleep(2); // give Confluence time to process the added page
+    }
+
+    private void waitForNextMinuteToStart() throws InterruptedException {
+        TimeUnit.SECONDS.sleep(60 - LocalTime.now().getSecond());
     }
 
 }

--- a/functional-tests/src/test/java/com/thoughtworks/gauge/test/confluence/ConfluenceClient.java
+++ b/functional-tests/src/test/java/com/thoughtworks/gauge/test/confluence/ConfluenceClient.java
@@ -28,6 +28,10 @@ public class ConfluenceClient {
         return (JSONArray) jsonResponse.get("results");
     }
 
+    public static void createPage(String spaceKey) {
+        sendConfluenceRequest(createPageRequest(spaceKey));
+    }
+
     private static HttpRequest createSpaceRequest(String spaceKey, String spaceName) {
         JSONObject description = new JSONObject().put("plain",
                 new JSONObject().put("value", spaceName).put("representation", "plain"));
@@ -35,6 +39,17 @@ public class ConfluenceClient {
         HttpRequest.Builder builder = baseConfluenceRequest();
         builder.uri(URI.create(baseSpaceAPIURL()));
         builder.POST(BodyPublishers.ofString(body.toString()));
+        return builder.build();
+    }
+
+    private static HttpRequest createPageRequest(String spaceKey) {
+        JSONObject space = new JSONObject().put("key", spaceKey);
+        JSONObject storage = new JSONObject().put("value", "content").put("representation", "storage");
+        JSONObject requestBody = new JSONObject().put("type", "page").put("title", "new page").put("space", space)
+                .put("body", new JSONObject().put("storage", storage));
+        HttpRequest.Builder builder = baseConfluenceRequest();
+        builder.uri(URI.create(baseContentAPIURL()));
+        builder.POST(BodyPublishers.ofString(requestBody.toString()));
         return builder.build();
     }
 

--- a/internal/confluence/api/client.go
+++ b/internal/confluence/api/client.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/agilepathway/gauge-confluence/internal/confluence/api/http"
+	"github.com/agilepathway/gauge-confluence/internal/confluence/time"
 	"github.com/agilepathway/gauge-confluence/internal/env"
 	"github.com/agilepathway/gauge-confluence/util"
 
@@ -14,13 +15,17 @@ import (
 
 // Client is a Confluence API client.
 type Client struct {
-	goconfluenceClient *goconfluence.API
 	httpClient         http.Client
+	goconfluenceClient *goconfluence.API
 }
 
 // NewClient initialises a new Client.
 func NewClient() Client {
-	return Client{confluenceClient(), httpClient()}
+	httpClient := http.NewClient(baseEndpoint(), username(), token())
+	goconfluenceClient, err := goconfluence.NewAPI(baseEndpoint(), username(), token())
+	util.Fatal("Error while creating Confluence API Client", err)
+
+	return Client{httpClient, goconfluenceClient}
 }
 
 // PublishPage publishes a page to Confluence as a child of the given parent page.
@@ -53,14 +58,22 @@ func (c *Client) PublishPage(spaceKey, title, body, parentPageID string) (pageID
 	return responseContent.ID, nil
 }
 
-// SpaceHomepageID retrieves the page ID for the given Space's homepage.
-func (c *Client) SpaceHomepageID(spaceKey string) (string, error) {
-	path := fmt.Sprintf("space?spaceKey=%s&expand=homepage", spaceKey)
+// SpaceHomepage provides the page ID, no. of children and created time for the given Space's homepage.
+func (c *Client) SpaceHomepage(spaceKey string) (string, int, string, error) {
+	path := fmt.Sprintf("space?spaceKey=%s&expand=homepage.children.page,homepage.history", spaceKey)
 
 	var homepageResponse struct {
 		Results []struct {
 			Homepage struct {
-				ID string `json:"id"`
+				ID      string `json:"id"`
+				History struct {
+					CreatedDate string `json:"createdDate"`
+				} `json:"history"`
+				Children struct {
+					Page struct {
+						Size int `json:"size"`
+					} `json:"page"`
+				} `json:"children"`
 			} `json:"homepage"`
 		} `json:"results"`
 	}
@@ -68,21 +81,44 @@ func (c *Client) SpaceHomepageID(spaceKey string) (string, error) {
 	err := c.httpClient.GetJSON(path, &homepageResponse)
 
 	if err != nil {
-		return "", err
+		return "", 0, "", err
 	}
 
-	return homepageResponse.Results[0].Homepage.ID, nil
+	h := homepageResponse.Results[0].Homepage
+
+	return h.ID, h.Children.Page.Size, h.History.CreatedDate, nil
 }
 
-func confluenceClient() *goconfluence.API {
-	api, err := goconfluence.NewAPI(baseEndpoint(), username(), token())
-	util.Fatal("Error while creating Confluence API Client", err)
+// IsSpaceModifiedSinceLastPublished returns true if any page was modified since the last publish
+//
+// The lastPublished parameter is a string in Confluence CQL format.
+func (c *Client) IsSpaceModifiedSinceLastPublished(spaceKey string, lastPublished string) (bool, error) {
+	query := goconfluence.SearchQuery{
+		CQL: fmt.Sprintf("space.key=\"%s\" and lastModified>\"%s\"", spaceKey, lastPublished),
+	}
+	result, err := c.goconfluenceClient.Search(query)
 
-	return api
+	if err != nil {
+		return true, err
+	}
+
+	return result.TotalSize > 0, nil
 }
 
-func httpClient() http.Client {
-	return http.NewClient(baseEndpoint(), username(), token())
+// PagesCreatedAt returns the pageIDs for pages created at the given cqlTime.
+func (c *Client) PagesCreatedAt(cqlTime string) []string {
+	query := goconfluence.SearchQuery{
+		CQL: fmt.Sprintf("created=\"%s\"", cqlTime),
+	}
+	result, _ := c.goconfluenceClient.Search(query)
+
+	pages := make([]string, len(result.Results))
+
+	for _, r := range result.Results {
+		pages = append(pages, r.Content.ID)
+	}
+
+	return pages
 }
 
 func baseEndpoint() string {
@@ -104,4 +140,65 @@ func baseURL() string {
 	}
 
 	return confluenceBaseURL
+}
+
+// Value contains the LastPublished time
+type Value struct {
+	LastPublished string `json:"lastPublished"`
+}
+
+// Version represents a Confluence version
+type Version struct {
+	Number    int  `json:"number"`
+	MinorEdit bool `json:"minorEdit"`
+}
+
+// Data represents a last published request
+type Data struct {
+	Value   Value   `json:"value"`
+	Version Version `json:"version"`
+}
+
+// UpdateLastPublished stores the time of publishing as a Confluence content property,
+// so that in the next run of the plugin it can check that the Confluence space has not
+// been edited manually in the meantime.
+//
+// The content property is attached to the Space homepage rather than to the Space itself, as
+// attaching the property to the Space requires admin permissions and we want to allow the
+// plugin to be run by non-admin users too.
+func (c *Client) UpdateLastPublished(homepageID string, currentVersion int) error {
+	path := fmt.Sprintf("content/%s/property/%s", homepageID, time.LastPublishedPropertyKey)
+	requestBody := Data{
+		Value{
+			LastPublished: time.Now().String(),
+		},
+		Version{
+			Number:    currentVersion + 1,
+			MinorEdit: true,
+		},
+	}
+
+	return c.httpClient.PutJSON(path, requestBody)
+}
+
+// LastPublished returns the last time Confluence specs were published for the space with the given homepageID
+func (c *Client) LastPublished(spaceHomepageID string) (time.LastPublished, error) {
+	path := fmt.Sprintf("content/%s/property/%s", spaceHomepageID, time.LastPublishedPropertyKey)
+
+	var resp struct {
+		Value struct {
+			LastPublished string `json:"lastPublished"`
+		} `json:"value"`
+		Version struct {
+			Number int `json:"number"`
+		} `json:"version"`
+	}
+
+	err := c.httpClient.GetJSON(path, &resp)
+
+	if err != nil && !strings.Contains(err.Error(), "404") {
+		return time.LastPublished{}, err
+	}
+
+	return time.NewLastPublished(resp.Value.LastPublished, resp.Version.Number), nil
 }

--- a/internal/confluence/homepage.go
+++ b/internal/confluence/homepage.go
@@ -1,0 +1,9 @@
+package confluence
+
+import "github.com/agilepathway/gauge-confluence/internal/confluence/time"
+
+type homepage struct {
+	id        string
+	created   time.Time
+	childless bool
+}

--- a/internal/confluence/homepage.go
+++ b/internal/confluence/homepage.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/agilepathway/gauge-confluence/internal/confluence/api"
 	"github.com/agilepathway/gauge-confluence/internal/confluence/time"
+	"github.com/agilepathway/gauge-confluence/internal/logger"
 )
 
 type homepage struct {
@@ -28,6 +29,8 @@ func newHomepage(spaceKey string, a api.Client) (homepage, error) {
 }
 
 func (h *homepage) cqlTimeOffset() int {
+	logger.Debugf(true, "Confluence homepage ID is %s for space %s", h.spaceKey, h.id)
+	logger.Debugf(true, "Homepage created at: %v (UTC)", h.created)
 	// nolint:gomnd
 	minOffset := -12 // the latest time zone on earth, 12 hours behind UTC
 	maxOffset := 14  // the earliest time zone on earth, 14 hours ahead of UTC
@@ -38,6 +41,7 @@ func (h *homepage) cqlTimeOffset() int {
 
 		for _, pg := range pages {
 			if pg == h.id {
+				logger.Debugf(true, "Successfully calculated time offset for Confluence CQL searches: UTC %+d hours", o)
 				return o
 			}
 		}

--- a/internal/confluence/homepage.go
+++ b/internal/confluence/homepage.go
@@ -1,9 +1,47 @@
 package confluence
 
-import "github.com/agilepathway/gauge-confluence/internal/confluence/time"
+import (
+	"fmt"
+
+	"github.com/agilepathway/gauge-confluence/internal/confluence/api"
+	"github.com/agilepathway/gauge-confluence/internal/confluence/time"
+)
 
 type homepage struct {
 	id        string
 	created   time.Time
 	childless bool
+	spaceKey  string
+	apiClient api.Client
+}
+
+func newHomepage(spaceKey string, a api.Client) (homepage, error) {
+	id, children, created, err := a.SpaceHomepage(spaceKey)
+
+	h := homepage{id: id, created: time.NewTime(created), childless: children == 0, spaceKey: spaceKey, apiClient: a}
+
+	if id == "" {
+		return h, fmt.Errorf("could not obtain a homepage ID for space: %s", spaceKey)
+	}
+
+	return h, err
+}
+
+func (h *homepage) cqlTimeOffset() int {
+	// nolint:gomnd
+	minOffset := -12 // the latest time zone on earth, 12 hours behind UTC
+	maxOffset := 14  // the earliest time zone on earth, 14 hours ahead of UTC
+
+	for o := minOffset; o <= maxOffset; o++ {
+		cqlTime := h.created.CQLFormat(o)
+		pages := h.apiClient.PagesCreatedAt(cqlTime)
+
+		for _, pg := range pages {
+			if pg == h.id {
+				return o
+			}
+		}
+	}
+
+	panic("Could not calculate the time offset")
 }

--- a/internal/confluence/homepage.go
+++ b/internal/confluence/homepage.go
@@ -29,6 +29,11 @@ func newHomepage(spaceKey string, a api.Client) (homepage, error) {
 	return h, err
 }
 
+// cqlTimeOffset calculates the number of hours that CQL queries are to be offset (against UTC) by,
+// for the Confluence instance that specs are being published to.  We calculate this on the fly each
+// time because it is not easy at all for the user of the plugin to know the time offset for CQL
+// queries required by their Confluence instance - see:
+// nolint[:lll] https://community.atlassian.com/t5/Confluence-questions/How-do-I-pass-a-UTC-time-as-the-value-of-lastModified-in-a-REST/qaq-p/1557903
 func (h *homepage) cqlTimeOffset() (int, error) {
 	logger.Debugf(true, "Confluence homepage ID is %s for space %s", h.spaceKey, h.id)
 	logger.Debugf(true, "Homepage created at: %v (UTC)", h.created)

--- a/internal/confluence/publisher.go
+++ b/internal/confluence/publisher.go
@@ -44,12 +44,9 @@ func makeSpecsMap(m *gauge_messages.SpecDetails) map[string]Spec {
 func (p *Publisher) Publish(specPaths []string) {
 	var err error
 
-	p.space.setup()
-
-	isSpaceValid, msg := p.space.isValid()
-
-	if !isSpaceValid {
-		p.printFailureMessage(msg)
+	err = p.space.setup()
+	if err != nil {
+		p.printFailureMessage(err)
 		return
 	}
 
@@ -66,6 +63,7 @@ func (p *Publisher) Publish(specPaths []string) {
 	}
 
 	err = p.space.updateLastPublished()
+
 	if err != nil {
 		p.printFailureMessage(err)
 		return

--- a/internal/confluence/publisher.go
+++ b/internal/confluence/publisher.go
@@ -80,13 +80,13 @@ func (p *Publisher) setupSpace() {
 		return
 	}
 
-	p.space.homepageID = h
+	p.space.homepage.id = h
 
-	p.space.homepageNumberOfChildren = ch
+	p.space.homepage.childless = ch == 0
 
-	p.space.homepageCreated = time.NewTime(cr)
+	p.space.homepage.created = time.NewTime(cr)
 
-	l, err := p.apiClient.LastPublished(p.space.homepageID)
+	l, err := p.apiClient.LastPublished(p.space.homepage.id)
 	if err != nil {
 		p.printFailureMessage(err)
 		return
@@ -94,7 +94,7 @@ func (p *Publisher) setupSpace() {
 
 	p.space.lastPublished = l
 
-	if l.Version == 0 || p.space.homepageNumberOfChildren == 0 {
+	if l.Version == 0 || p.space.homepage.childless {
 		return
 	}
 
@@ -115,11 +115,11 @@ func (p *Publisher) cqlTimeOffset() int {
 	maxOffset := 14  // the earliest time zone on earth, 14 hours ahead of UTC
 
 	for o := minOffset; o <= maxOffset; o++ {
-		cqlTime := p.space.homepageCreated.FormatTimeForCQLSearch(o)
+		cqlTime := p.space.homepage.created.FormatTimeForCQLSearch(o)
 		pages := p.apiClient.PagesCreatedAt(cqlTime)
 
 		for _, pg := range pages {
-			if pg == p.space.homepageID {
+			if pg == p.space.homepage.id {
 				return o
 			}
 		}
@@ -182,5 +182,5 @@ func (p *Publisher) publishPage(pg page) (err error) {
 }
 
 func (p *Publisher) updateLastPublished() error {
-	return p.apiClient.UpdateLastPublished(p.space.homepageID, p.space.lastPublished.Version)
+	return p.apiClient.UpdateLastPublished(p.space.homepage.id, p.space.lastPublished.Version)
 }

--- a/internal/confluence/space.go
+++ b/internal/confluence/space.go
@@ -15,7 +15,7 @@ type space struct {
 	lastPublished              time.LastPublished
 	modifiedSinceLastPublished bool
 	apiClient                  api.Client
-	cqlOffset                  int
+	cqlOffset                  int // Number of hours that CQL queries are to be offset (against UTC) by
 }
 
 // newSpace initialises a new space.

--- a/internal/confluence/space.go
+++ b/internal/confluence/space.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/agilepathway/gauge-confluence/internal/confluence/api"
 	"github.com/agilepathway/gauge-confluence/internal/confluence/time"
 )
 
@@ -13,11 +14,65 @@ type space struct {
 	publishedPages             map[string]page // Pages published by current invocation of the plugin, keyed by filepath
 	lastPublished              time.LastPublished
 	modifiedSinceLastPublished bool
+	apiClient                  api.Client
 }
 
 // newSpace initialises a new space.
-func newSpace(key string) space {
-	return space{key: key, publishedPages: make(map[string]page)}
+func newSpace(key string, apiClient api.Client) space {
+	return space{key: key, publishedPages: make(map[string]page), apiClient: apiClient}
+}
+
+func (s *space) setup() {
+	h, ch, cr, err := s.apiClient.SpaceHomepage(s.key)
+	if err != nil {
+		s.printFailureMessage(err)
+		return
+	}
+
+	s.homepage.id = h
+	s.homepage.childless = ch == 0
+	s.homepage.created = time.NewTime(cr)
+
+	l, err := s.apiClient.LastPublished(s.homepage.id)
+	if err != nil {
+		s.printFailureMessage(err)
+		return
+	}
+
+	s.lastPublished = l
+
+	if l.Version == 0 || s.homepage.childless {
+		return
+	}
+
+	cqlTime := s.lastPublished.Time.FormatTimeForCQLSearch(s.cqlTimeOffset())
+
+	m, err := s.apiClient.IsSpaceModifiedSinceLastPublished(s.key, cqlTime)
+	if err != nil {
+		s.printFailureMessage(err)
+		return
+	}
+
+	s.modifiedSinceLastPublished = m
+}
+
+func (s *space) cqlTimeOffset() int {
+	// nolint:gomnd
+	minOffset := -12 // the latest time zone on earth, 12 hours behind UTC
+	maxOffset := 14  // the earliest time zone on earth, 14 hours ahead of UTC
+
+	for o := minOffset; o <= maxOffset; o++ {
+		cqlTime := s.homepage.created.FormatTimeForCQLSearch(o)
+		pages := s.apiClient.PagesCreatedAt(cqlTime)
+
+		for _, pg := range pages {
+			if pg == s.homepage.id {
+				return o
+			}
+		}
+	}
+
+	panic("Could not calculate the time offset")
 }
 
 func (s *space) isValid() (bool, string) {
@@ -53,4 +108,12 @@ func (s *space) checkForDuplicateTitle(given page) error {
 	}
 
 	return nil
+}
+
+func (s *space) updateLastPublished() error {
+	return s.apiClient.UpdateLastPublished(s.homepage.id, s.lastPublished.Version)
+}
+
+func (s *space) printFailureMessage(i interface{}) {
+	fmt.Printf("Failed: %v", i)
 }

--- a/internal/confluence/space.go
+++ b/internal/confluence/space.go
@@ -9,9 +9,7 @@ import (
 
 type space struct {
 	key                        string
-	homepageID                 string
-	homepageNumberOfChildren   int
-	homepageCreated            time.Time
+	homepage                   homepage
 	publishedPages             map[string]page // Pages published by current invocation of the plugin, keyed by filepath
 	lastPublished              time.LastPublished
 	modifiedSinceLastPublished bool
@@ -28,7 +26,7 @@ func (s *space) isValid() (bool, string) {
 		return false, fmt.Sprintf("the space has been modified since the last publish. Space key: %s", s.key)
 	}
 
-	if s.homepageID == "" {
+	if s.homepage.id == "" {
 		return false, fmt.Sprintf("could not obtain a homepage ID for space: %s", s.key)
 	}
 
@@ -40,7 +38,7 @@ func (s *space) parentPageIDFor(path string) string {
 	parentPageID := s.publishedPages[parentDir].id
 
 	if parentPageID == "" {
-		return s.homepageID
+		return s.homepage.id
 	}
 
 	return parentPageID

--- a/internal/confluence/space.go
+++ b/internal/confluence/space.go
@@ -30,7 +30,11 @@ func (s *space) setup() error {
 	}
 
 	s.homepage = h
-	s.cqlOffset = s.homepage.cqlTimeOffset()
+	s.cqlOffset, err = s.homepage.cqlTimeOffset()
+
+	if err != nil {
+		return err
+	}
 
 	lastPublishedString, version, err := s.apiClient.LastPublished(s.homepage.id, time.LastPublishedPropertyKey)
 	if err != nil {

--- a/internal/confluence/time/last_published.go
+++ b/internal/confluence/time/last_published.go
@@ -1,0 +1,19 @@
+package time
+
+// LastPublishedPropertyKey is the name of the Confluence content property key used to store the last published time
+const LastPublishedPropertyKey = "lastPublished"
+
+// LastPublished represents the last time Confluence specs were published for a space
+type LastPublished struct {
+	Time    Time
+	Version int // version is the Confluence content property version, which is incremented on every publish
+}
+
+// NewLastPublished creates a new LastPublished from the given time in Confluence format and version.
+func NewLastPublished(lastPublishedInConfluenceFormat string, version int) LastPublished {
+	if lastPublishedInConfluenceFormat == "" {
+		return LastPublished{}
+	}
+
+	return LastPublished{Time: NewTime(lastPublishedInConfluenceFormat), Version: version}
+}

--- a/internal/confluence/time/time.go
+++ b/internal/confluence/time/time.go
@@ -27,11 +27,10 @@ func NewTime(timeInConfluenceFormat string) Time {
 	return Time{t}
 }
 
-// FormatTimeForCQLSearch formats a time so it can be used in Confluence CQL searches.
+// CQLFormat formats a time so it can be used in Confluence CQL searches.
 //
 // See https://developer.atlassian.com/server/confluence/advanced-searching-using-cql/.
-//
-func (t Time) FormatTimeForCQLSearch(cqlOffset int) string {
+func (t Time) CQLFormat(cqlOffset int) string {
 	cqlTime := t.cqlTime(cqlOffset)
 	return fmt.Sprintf("%d-%02d-%02d %02d:%02d",
 		cqlTime.Year(), cqlTime.Month(), cqlTime.Day(), cqlTime.Hour(), cqlTime.Minute())

--- a/internal/confluence/time/time.go
+++ b/internal/confluence/time/time.go
@@ -1,0 +1,71 @@
+// Package time provides functionality for working with dates and times in Confluence's expected formats.
+package time
+
+import (
+	"fmt"
+	gotime "time"
+
+	"github.com/agilepathway/gauge-confluence/util"
+)
+
+// ConfluenceFormat is the format that Confluence uses to store times.
+// The format is RFC3339 at millisecond precision.
+//
+// The format includes any trailing millisecond zeros, as Confluence stores any trailing zeros.
+const confluenceFormat = "2006-01-02T15:04:05.000Z07:00"
+
+// Time wraps Confluence time functionality around a time
+type Time struct {
+	time gotime.Time
+}
+
+// NewTime creates a new Time from the given time in Confluence format.
+func NewTime(timeInConfluenceFormat string) Time {
+	t, err := gotime.ParseInLocation(confluenceFormat, timeInConfluenceFormat, gotime.UTC)
+	util.Fatal(fmt.Sprintf("Could not parse time: %s", timeInConfluenceFormat), err)
+
+	return Time{t}
+}
+
+// FormatTimeForCQLSearch formats a time so it can be used in Confluence CQL searches.
+//
+// See https://developer.atlassian.com/server/confluence/advanced-searching-using-cql/.
+//
+func (t Time) FormatTimeForCQLSearch(cqlOffset int) string {
+	cqlTime := t.cqlTime(cqlOffset)
+	return fmt.Sprintf("%d-%02d-%02d %02d:%02d",
+		cqlTime.Year(), cqlTime.Month(), cqlTime.Day(), cqlTime.Hour(), cqlTime.Minute())
+}
+
+func (t Time) cqlTime(offset int) gotime.Time {
+	d := gotime.Duration(abs(offset))
+	u := t.time.UTC()
+
+	switch {
+	case offset == 0:
+		return u
+	case offset > 0:
+		return u.Add(gotime.Hour * d)
+	case offset < 0:
+		return u.Add(-gotime.Hour * d)
+	}
+
+	panic("Unreachable code")
+}
+
+func abs(x int) int {
+	if x < 0 {
+		return -x
+	}
+
+	return x
+}
+
+func (t Time) String() string {
+	return t.time.UTC().Format(confluenceFormat)
+}
+
+// Now returns the current UTC time (not the local time) in Confluence's expected time format.
+func Now() Time {
+	return Time{gotime.Now().UTC()}
+}

--- a/internal/errors/retry.go
+++ b/internal/errors/retry.go
@@ -1,0 +1,30 @@
+package errors
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/agilepathway/gauge-confluence/internal/logger"
+)
+
+// Retry allows flaky functionality to be retried.
+// Based on: https://github.com/abourget/blog/blob/master/content/post/my-favorite-golang-retry-function.md
+// Also see: https://stackoverflow.com/a/47606858
+func Retry(attempts int, sleep time.Duration, f func() error) (err error) {
+	for i := 0; ; i++ {
+		err = f()
+		if err == nil {
+			return
+		}
+
+		if i >= (attempts - 1) {
+			break
+		}
+
+		time.Sleep(sleep)
+
+		logger.Debug(true, fmt.Sprintln("retrying after error:", err))
+	}
+
+	return fmt.Errorf("after %d attempts, last error: %s", attempts, err)
+}

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "confluence",
-    "version": "0.6.0",
+    "version": "0.7.0",
     "name": "Confluence",
     "description": "Publishes Gauge specifications to Confluence",
     "install": {


### PR DESCRIPTION
Any Confluence space that the plugin publishes specs to should be used
just for publishing specs, i.e. it should only contain specs and not
have any pages that were manually created by a user in Confluence.
This PR adds a safety check before publishing to ensure this. In a
future PR the plugin will delete all existing pages in the
Confluence space before publishing, so the safety check is an important
one (to ensure that no manually created pages are inadvertently
deleted).