### PR TITLE
Ensure test Confluence spaces have unique keys

### DIFF
--- a/functional-tests/src/test/java/com/thoughtworks/gauge/test/confluence/Confluence.java
+++ b/functional-tests/src/test/java/com/thoughtworks/gauge/test/confluence/Confluence.java
@@ -14,6 +14,7 @@ import java.io.IOException;
 import java.time.Instant;
 import java.time.LocalTime;
 import java.util.concurrent.TimeUnit;
+import java.util.UUID;
 
 public class Confluence {
 
@@ -26,17 +27,13 @@ public class Confluence {
 
     @BeforeScenario
     public void BeforeScenario() {
-        ScenarioDataStore.put(SCENARIO_SPACE_KEY_NAME, currentTimeInMilliseconds());
+        ScenarioDataStore.put(SCENARIO_SPACE_KEY_NAME, generateUniqueSpaceKeyName());
         ConfluenceClient.createSpace(getScenarioSpaceKey(), SCENARIO_SPACE_NAME);
     }
 
     @AfterScenario
     public void AfterScenario() {
         ConfluenceClient.deleteSpace(getScenarioSpaceKey());
-    }
-
-    public String currentTimeInMilliseconds() {
-        return String.valueOf(Instant.now().toEpochMilli());
     }
 
     @Step("Published pages are: <table>")
@@ -66,6 +63,10 @@ public class Confluence {
 
     private void waitForNextMinuteToStart() throws InterruptedException {
         TimeUnit.SECONDS.sleep(60 - LocalTime.now().getSecond());
+    }
+
+    private String generateUniqueSpaceKeyName() {
+        return UUID.randomUUID().toString().replace("-", "");
     }
 
 }

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "confluence",
-    "version": "0.7.3",
+    "version": "0.7.4",
     "name": "Confluence",
     "description": "Publishes Gauge specifications to Confluence",
     "install": {


### PR DESCRIPTION
Prior to this pull request we were using the current time in 
milliseconds as the Confluence space key in our functional tests.  
There was a chance though that there could be naming clashes when
running multiple tests in parallel, so this pull request uses a 
[UUID][1] as the unique identifier instead.

This change is just in our functional tests code, not in the actual
plugin production code.

[1]: https://www.baeldung.com/java-uuid