### PR TITLE
Do not publish directories with no specs

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,6 +10,13 @@ issues:
   # Default value for this option is true.
   exclude-use-default: false
 
+
+  exclude-rules:
+    # As per https://github.com/golangci/golangci-lint/issues/207#issuecomment-534771981
+    - linters:
+        - lll
+      source: "^// http"
+
 linters:
   # enable-all is deprecated, so enable linters individually
   enable:

--- a/functional-tests/specs/do_not_publish_concepts.spec
+++ b/functional-tests/specs/do_not_publish_concepts.spec
@@ -1,0 +1,36 @@
+# Concepts are not published
+
+
+## Concepts are not published
+
+* Publish specs to Confluence:
+
+   |heading  |path |concept|
+   |---------|-----|-------|
+   |A spec   |specs|       |
+   |A concept|specs|yes    |
+
+* Published pages are:
+
+   |title     |parent    |
+   |----------|----------|
+   |Space Home|          |
+   |specs     |Space Home|
+   |A spec    |specs     |
+
+## A directory that just contains concepts is not published
+
+* Publish specs to Confluence:
+
+   |heading                      |path          |concept|
+   |-----------------------------|--------------|-------|
+   |A spec in the specs dir      |specs         |       |
+   |A concept in the concepts dir|specs/concepts|yes    |
+
+* Published pages are:
+
+   |title                  |parent    |
+   |-----------------------|----------|
+   |Space Home             |          |
+   |specs                  |Space Home|
+   |A spec in the specs dir|specs     |

--- a/functional-tests/src/test/java/com/thoughtworks/gauge/test/common/builders/ConceptBuilder.java
+++ b/functional-tests/src/test/java/com/thoughtworks/gauge/test/common/builders/ConceptBuilder.java
@@ -1,0 +1,33 @@
+package com.thoughtworks.gauge.test.common.builders;
+
+import com.thoughtworks.gauge.Table;
+import com.thoughtworks.gauge.test.common.Concept;
+
+import static com.thoughtworks.gauge.test.common.GaugeProject.getCurrentProject;
+
+public class ConceptBuilder {
+    private String conceptName;
+    private Table steps;
+    private String subDirPath;
+
+    public ConceptBuilder withName(String conceptName) {
+        this.conceptName = conceptName;
+        return this;
+    }
+
+    public ConceptBuilder withSteps(Table steps) {
+        this.steps = steps;
+        return this;
+    }
+
+    public ConceptBuilder withSubDirPath(String subDirPath) {
+        this.subDirPath = subDirPath;
+        return this;
+    }
+
+    public Concept build() throws Exception {
+        Concept concept = getCurrentProject().createConcept(subDirPath, conceptName, steps);
+        getCurrentProject().addConcepts(concept);
+        return concept;
+    }
+}

--- a/functional-tests/src/test/java/com/thoughtworks/gauge/test/confluence/Confluence.java
+++ b/functional-tests/src/test/java/com/thoughtworks/gauge/test/confluence/Confluence.java
@@ -11,7 +11,6 @@ import com.thoughtworks.gauge.test.implementation.Console;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
-import java.time.Instant;
 import java.time.LocalTime;
 import java.util.concurrent.TimeUnit;
 import java.util.UUID;

--- a/functional-tests/src/test/java/com/thoughtworks/gauge/test/implementation/Specification.java
+++ b/functional-tests/src/test/java/com/thoughtworks/gauge/test/implementation/Specification.java
@@ -3,6 +3,7 @@ package com.thoughtworks.gauge.test.implementation;
 import com.thoughtworks.gauge.Step;
 import com.thoughtworks.gauge.Table;
 import com.thoughtworks.gauge.TableRow;
+import com.thoughtworks.gauge.test.common.builders.ConceptBuilder;
 import com.thoughtworks.gauge.test.common.builders.SpecificationBuilder;
 
 public class Specification {
@@ -11,13 +12,21 @@ public class Specification {
     public void createSpecs(Table specs) throws Exception {
         for (int i = 0; i < specs.getTableRows().size(); i++) {
             TableRow row = specs.getTableRows().get(i);
-            createSpec(row.getCell("heading"), row.getCell("path"), "spec" + i);
+            if (row.getCell("concept").trim().toLowerCase().equals("yes")) {
+                createConcept(row.getCell("heading"), row.getCell("path"));
+            } else {
+                createSpec(row.getCell("heading"), row.getCell("path"), "spec" + i);
+            }
         }
     }
 
     public void createSpec(String specName, String subFolder, String filename) throws Exception {
         new SpecificationBuilder().withScenarioName("A scenario").withSpecName(specName).withSteps(Steps.example())
                 .withSubDirPath(subFolder).withFilename(filename).buildAndAddToProject(false);
+    }
+
+    public void createConcept(String conceptName, String subFolder) throws Exception {
+        new ConceptBuilder().withName(conceptName).withSubDirPath(subFolder).build();
     }
 
 }

--- a/internal/confluence/api/client.go
+++ b/internal/confluence/api/client.go
@@ -57,6 +57,11 @@ func (c *Client) PublishPage(spaceKey, title, body, parentPageID string) (pageID
 	return responseContent.ID, nil
 }
 
+// DeletePage deletes a page from Confluence
+func (c *Client) DeletePage(pageID string) (err error) {
+	return c.httpClient.DeleteContent(pageID)
+}
+
 // SpaceHomepage provides the page ID, no. of children and created time for the given Space's homepage.
 func (c *Client) SpaceHomepage(spaceKey string) (string, int, string, error) {
 	path := fmt.Sprintf("space?spaceKey=%s&expand=homepage.children.page,homepage.history", spaceKey)

--- a/internal/confluence/homepage.go
+++ b/internal/confluence/homepage.go
@@ -36,7 +36,7 @@ func newHomepage(spaceKey string, a api.Client) (homepage, error) {
 // for the Confluence instance that specs are being published to.  We calculate this on the fly each
 // time because it is not easy at all for the user of the plugin to know the time offset for CQL
 // queries required by their Confluence instance - see:
-// nolint[:lll] https://community.atlassian.com/t5/Confluence-questions/How-do-I-pass-a-UTC-time-as-the-value-of-lastModified-in-a-REST/qaq-p/1557903
+// https://community.atlassian.com/t5/Confluence-questions/How-do-I-pass-a-UTC-time-as-the-value-of-lastModified-in-a-REST/qaq-p/1557903
 func (h *homepage) cqlTimeOffset() (int, error) {
 	logger.Debugf(true, "Confluence homepage ID is %s for space %s", h.spaceKey, h.id)
 	logger.Debugf(true, "Homepage created at: %v (UTC)", h.created)

--- a/internal/confluence/publisher.go
+++ b/internal/confluence/publisher.go
@@ -17,7 +17,7 @@ import (
 // Publisher publishes Gauge specifications to Confluence.
 type Publisher struct {
 	apiClient api.Client
-	space     space
+	space     space           // Represents the Confluence Space that is published to
 	specs     map[string]Spec // keyed by filepath
 }
 
@@ -77,7 +77,12 @@ func (p *Publisher) printFailureMessage(s interface{}) {
 }
 
 func (p *Publisher) publishAllSpecsUnder(baseSpecPath string) (err error) {
-	return filepath.WalkDir(baseSpecPath, p.publishIfDirOrSpec)
+	err = filepath.WalkDir(baseSpecPath, p.publishIfDirOrSpec)
+	if err != nil {
+		return err
+	}
+
+	return p.space.deleteEmptyDirPages()
 }
 
 func (p *Publisher) publishIfDirOrSpec(path string, d fs.DirEntry, err error) error {

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "confluence",
-    "version": "0.7.4",
+    "version": "0.8.0",
     "name": "Confluence",
     "description": "Publishes Gauge specifications to Confluence",
     "install": {


### PR DESCRIPTION
This commit ensures that any directories without any specs in them are
not published to Confluence.  Prior to this commit these directories
were being published, appearing in Confluence as pages without any
content or subpages. This was distracting when trying to browse the
published specs in Confluence.

One example of this manifesting itself prior to this commit was if the
Gauge [concept files][1] were put into their own concepts directory.
As we only publish specs and not concepts to Confluence, having concepts
in their own directory was leading to empty directory pages being
published prior to this commit.

The functional tests implementation code in this commit was lifted and
shifted with only minor alterations from [the functional tests repo for
core Gauge][2] (just like the existing functional test implementation
code) - no point in reinventing the wheel.

One other noteworthy thing is that the code to delete a page uses the
low level [Go net http client][3], rather than the higher level
[confluence-go-api client][4]. This is because there was a subtle bug
with the confluence-go-api client (it was returning an error even after
a successful delete, despite returning [the correct 204 status
code][5]). It may be worth removing the confluence-go-api client
altogether in a future pull request, as [minimising dependencies is
generally a good thing][6].

[1]: https://docs.gauge.org/writing-specifications.html#concepts
[2]: https://github.com/getgauge/gauge-tests
[3]: https://pkg.go.dev/net/http
[4]: https://github.com/Virtomize/confluence-go-api
[5]: https://developer.atlassian.com/server/confluence/confluence-rest-api-examples/#delete-a-page
[6]: https://endjin.com/blog/2018/09/whose-package-is-it-anyway-why-its-important-to-minimise-dependencies-in-your-solutions