### PR TITLE
Delete existing published specs before publishing

### DIFF
--- a/functional-tests/specs/concepts/publish_specifed_number_ofspecs.cpt
+++ b/functional-tests/specs/concepts/publish_specifed_number_ofspecs.cpt
@@ -1,0 +1,7 @@
+# Publish <number> specs to Confluence
+
+* Initialize an empty Gauge project
+
+* Create <number> specs
+
+* Publish Confluence Documentation for the current project

--- a/functional-tests/specs/delete_specs_before_publishing.spec
+++ b/functional-tests/specs/delete_specs_before_publishing.spec
@@ -1,0 +1,24 @@
+# Delete existing published specs before publishing
+
+## The plugin deletes all existing published specs before publishing
+It is safe to do this as before doing so we abort if the Space has been manually edited since the last publish.
+NB The Space homepage is not deleted, it is just the published specs that are deleted (i.e. all the other pages
+in the Space apart from the homepage).
+
+* Publish "26" specs to Confluence
+The default limit for pagination on the Confluence API is 25, so we publish 26 specs here to ensure that the
+plugin handles pagination correctly when deleting the specs on the second publish below.
+
+* Publish specs to Confluence:
+
+   |heading     |
+   |------------|
+   |Another spec|
+
+* Published pages are:
+
+   |title                         |parent      |
+   |------------------------------|------------|
+   |Space Home                    |            |
+   |specs                         |Space Home  |
+   |Another spec                  |specs       |

--- a/functional-tests/src/test/java/com/thoughtworks/gauge/test/implementation/Specification.java
+++ b/functional-tests/src/test/java/com/thoughtworks/gauge/test/implementation/Specification.java
@@ -1,5 +1,7 @@
 package com.thoughtworks.gauge.test.implementation;
 
+import java.util.Arrays;
+
 import com.thoughtworks.gauge.Step;
 import com.thoughtworks.gauge.Table;
 import com.thoughtworks.gauge.TableRow;
@@ -18,6 +20,16 @@ public class Specification {
                 createSpec(row.getCell("heading"), row.getCell("path"), "spec" + i);
             }
         }
+    }
+
+    @Step("Create <number> specs")
+    public void createSpecifiedNumberOfSpecs(int numberOfSpecs) throws Exception {
+        Table t = new Table(Arrays.asList("heading"));
+        for (int i = 0; i < numberOfSpecs; i++) {
+            t.addRow(Arrays.asList(Integer.toString(i)));
+        }
+
+        createSpecs(t);
     }
 
     public void createSpec(String specName, String subFolder, String filename) throws Exception {

--- a/internal/confluence/api/client.go
+++ b/internal/confluence/api/client.go
@@ -140,20 +140,20 @@ func (c *Client) IsSpaceModifiedSinceLastPublished(spaceKey string, lastPublishe
 	return result.TotalSize > 0, nil
 }
 
-// PagesCreatedAt returns the pageIDs for pages created at the given cqlTime.
-func (c *Client) PagesCreatedAt(cqlTime string) []string {
+// WasPageCreatedAt returns true if the page was created at the given time.
+func (c *Client) WasPageCreatedAt(cqlTime string, pageID string) bool {
 	query := goconfluence.SearchQuery{
-		CQL: fmt.Sprintf("created=\"%s\"", cqlTime),
+		CQL: fmt.Sprintf("created=\"%s\" AND ID=\"%s\"", cqlTime, pageID),
 	}
 	result, _ := c.goconfluenceClient.Search(query)
 
-	pages := make([]string, len(result.Results))
-
 	for _, r := range result.Results {
-		pages = append(pages, r.Content.ID)
+		if pageID == r.Content.ID {
+			return true
+		}
 	}
 
-	return pages
+	return false
 }
 
 func baseEndpoint() string {

--- a/internal/confluence/homepage.go
+++ b/internal/confluence/homepage.go
@@ -49,14 +49,11 @@ func (h *homepage) cqlTimeOffset() (int, error) {
 	err := errors.Retry(5, 1000, func() (err error) { //nolint:gomnd
 		for o := minOffset; o <= maxOffset; o++ {
 			cqlTime := h.created.CQLFormat(o)
-			pages := h.apiClient.PagesCreatedAt(cqlTime)
 
-			for _, pg := range pages {
-				if pg == h.id {
-					logger.Debugf(true, "Successfully calculated time offset for Confluence CQL searches: UTC %+d hours", o)
-					offset = o
-					return
-				}
+			if h.apiClient.WasPageCreatedAt(cqlTime, h.id) {
+				logger.Debugf(true, "Successfully calculated time offset for Confluence CQL searches: UTC %+d hours", o)
+				offset = o
+				return
 			}
 		}
 		return fmt.Errorf("could not calculate time offset for Confluence CQL searches")

--- a/internal/confluence/publisher.go
+++ b/internal/confluence/publisher.go
@@ -50,6 +50,13 @@ func (p *Publisher) Publish(specPaths []string) {
 		return
 	}
 
+	err = p.space.deleteAllPagesExceptHomepage()
+
+	if err != nil {
+		p.printFailureMessage(err)
+		return
+	}
+
 	for _, specPath := range specPaths {
 		err = p.publishAllSpecsUnder(specPath)
 		if err != nil {

--- a/internal/confluence/space.go
+++ b/internal/confluence/space.go
@@ -108,6 +108,10 @@ func (s *space) updateLastPublished() error {
 	return s.apiClient.SetContentProperty(s.homepage.id, time.LastPublishedPropertyKey, value, s.lastPublished.Version+1)
 }
 
+func (s *space) deleteAllPagesExceptHomepage() (err error) {
+	return s.apiClient.DeleteAllPagesInSpaceExceptHomepage(s.key, s.homepage.id)
+}
+
 // deleteEmptyDirPages deletes any pages that the plugin has published to in this run
 // that are empty directories
 func (s *space) deleteEmptyDirPages() (err error) {

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "confluence",
-    "version": "0.8.0",
+    "version": "0.9.0",
     "name": "Confluence",
     "description": "Publishes Gauge specifications to Confluence",
     "install": {


### PR DESCRIPTION
It is safe to do this as before doing so we abort if the Space has been
manually edited since the last publish.

NB the Space homepage is not deleted, just the published specs (i.e. all
other pages except the homepage).