### PR TITLE
Fix typo in helper script

### DIFF
--- a/functional-tests/src/test/java/com/thoughtworks/gauge/test/confluence/SpaceManager.java
+++ b/functional-tests/src/test/java/com/thoughtworks/gauge/test/confluence/SpaceManager.java
@@ -16,7 +16,7 @@ public class SpaceManager {
     @Step("Create space")
     public void createSpace() {
         ConfluenceClient.createSpace(spaceKey(), spaceKey());
-        System.out.println("Deleted space: " + spaceKey());
+        System.out.println("Created space: " + spaceKey());
     }
 
     @Step("Delete all spaces named <space name>")

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "confluence",
-    "version": "0.9.0",
+    "version": "0.9.1",
     "name": "Confluence",
     "description": "Publishes Gauge specifications to Confluence",
     "install": {


### PR DESCRIPTION
This typo wasn't affecting the behaviour of the plugin itself in any
way, as it was just in a helper script.