### PR TITLE
Do not publish if first time & Space is not empty

### DIFF
--- a/.github/workflows/check-commit-message.yml
+++ b/.github/workflows/check-commit-message.yml
@@ -21,5 +21,5 @@ jobs:
         uses: mristin/opinionated-commit-message@v2.2.0
         with:
           allow-one-liners: 'true'
-          additional-verbs: 'export, parse, append, skip, store, retry'
+          additional-verbs: 'export, parse, append, skip, store, retry, tidy'
 

--- a/functional-tests/specs/space_validity.spec
+++ b/functional-tests/specs/space_validity.spec
@@ -7,6 +7,7 @@ NB The specs can still appear alongside your existing manually created Confluenc
 in other spaces, by using Confluence's [Include Page macro][2].  This macro
 [allows you to include the full page tree of specs in as many other spaces as you like][3].
 
+
 ## Publishing is aborted if the Space has been manually edited since the last publish
 
 * Publish "1" specs to Confluence
@@ -16,6 +17,17 @@ in other spaces, by using Confluence's [Include Page macro][2].  This macro
 * Publish "1" specs to Confluence
 
 * The error message "Failed: the space has been modified since the last publish" should be output
+
+
+## Publishing is aborted if the Space is not empty and has never been published to
+The Space can have a homepage but no other pages before the first ever publish to the Space.
+
+* Manually add a page to the Confluence space
+
+* Publish "1" specs to Confluence
+
+* The error message "Failed: the space must be empty when you publish for the first time" should be output
+
 
 
 __________________________________________________________________________________________

--- a/functional-tests/specs/space_validity.spec
+++ b/functional-tests/specs/space_validity.spec
@@ -1,6 +1,4 @@
 # Confluence Space validity
-
-## Publishing is aborted if the Space has been manually edited since the last publish
 This Gauge Confluence plugin requires that the specs for a given Gauge project are published to
 their own dedicated [Confluence Space][1], with no manual edits or additions in Confluence.
 Having the Space only contain published Gauge specs ensures that there is no danger of the plugin
@@ -9,19 +7,13 @@ NB The specs can still appear alongside your existing manually created Confluenc
 in other spaces, by using Confluence's [Include Page macro][2].  This macro
 [allows you to include the full page tree of specs in as many other spaces as you like][3].
 
-* Publish specs to Confluence:
+## Publishing is aborted if the Space has been manually edited since the last publish
 
-   |heading|
-   |-------|
-   |A spec |
+* Publish "1" specs to Confluence
 
 * Manually add a page to the Confluence space
 
-* Publish specs to Confluence:
-
-   |heading     |
-   |------------|
-   |Another spec|
+* Publish "1" specs to Confluence
 
 * The error message "Failed: the space has been modified since the last publish" should be output
 

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "confluence",
-    "version": "0.9.1",
+    "version": "0.10.0",
     "name": "Confluence",
     "description": "Publishes Gauge specifications to Confluence",
     "install": {


### PR DESCRIPTION
The Space can have a homepage but no other pages before the first ever
publish to the Space.  Having the Space only ever contain published
Gauge specs ensures that there is no danger of the plugin inadvertently
overwriting or deleting manually created Confluence pages.