### PR TITLE
Add helper script to print space pages

### DIFF
--- a/functional-tests/scripts/manage_space.spec
+++ b/functional-tests/scripts/manage_space.spec
@@ -10,3 +10,6 @@ These specs are just helper functions - they do not document or exercise the Gau
 
 ## Delete all spaces with given name
 * Delete all spaces named "Change me to the name of the space you want to delete"
+
+## Print space content
+* Print content for space with key "e683d1a0712948cebe70dae5afb55354"

--- a/functional-tests/src/test/java/com/thoughtworks/gauge/test/confluence/SpaceManager.java
+++ b/functional-tests/src/test/java/com/thoughtworks/gauge/test/confluence/SpaceManager.java
@@ -27,6 +27,12 @@ public class SpaceManager {
         }
     }
 
+    @Step("Print content for space with key <space key>")
+    public void getContentForSpace(String spaceKey) {
+        JSONArray content = ConfluenceClient.getAllPages(spaceKey);
+        System.out.println(content);
+    }
+
     private void deleteSpaceIfNamed(JSONObject sp, String spaceName) {
         if (spaceName.equals(sp.get("name"))) {
             ConfluenceClient.deleteSpace((String) sp.get("key"));

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "confluence",
-    "version": "0.10.0",
+    "version": "0.10.1",
     "name": "Confluence",
     "description": "Publishes Gauge specifications to Confluence",
     "install": {


### PR DESCRIPTION
This helper script runs as a Gauge spec but isn't part of the suite of
functional tests for the plugin, it's just a utility function which can
be useful when debugging the plugin manually.