### PR TITLE
Fix bug when republishing after aborted attempt

### DIFF
--- a/functional-tests/specs/duplicate_scenario_headings.spec
+++ b/functional-tests/specs/duplicate_scenario_headings.spec
@@ -30,3 +30,22 @@ chance of duplicate spec headings.
 * Output contains <result>
 * Output contains <message>
 
+## Republishing after fixing the duplicate spec headings or directory names works fine
+
+* Publish specs to Confluence:
+
+   |heading|
+   |-------|
+   |same   |
+   |same   |
+
+* Output contains "Failed: 2 specs have the same heading"
+
+* Publish specs to Confluence:
+
+   |heading      |
+   |-------------|
+   |same same    |
+   |but different|
+
+* Output contains "Success"

--- a/internal/confluence/publisher.go
+++ b/internal/confluence/publisher.go
@@ -65,7 +65,9 @@ func (p *Publisher) Publish(specPaths []string) {
 	}
 
 	if err != nil {
+		p.space.updateLastPublished() //nolint:errcheck,gosec
 		p.printFailureMessage(err)
+
 		return
 	}
 

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "confluence",
-    "version": "0.10.1",
+    "version": "0.10.2",
     "name": "Confluence",
     "description": "Publishes Gauge specifications to Confluence",
     "install": {


### PR DESCRIPTION
The bug was caused because prior to this commit we were only
incrementing the lastPublished counter if publishing succeeded. This
meant that for instance if publishing was aborted the very first time
that the plugin was ran, it would fail again afterwards as it would
mistakenly think there had been a manual edit of the Confluence space.

The fix in this commit is to ensure that we also increment the
lastPublished counter when there is an error encountered during
publishing.