### PR TITLE
Remove debugging output from console

### DIFF
--- a/internal/confluence/homepage.go
+++ b/internal/confluence/homepage.go
@@ -19,9 +19,9 @@ type homepage struct {
 
 func newHomepage(spaceKey string, a api.Client) (homepage, error) {
 	id, children, created, err := a.SpaceHomepage(spaceKey)
-	logger.Debugf(true, "Space homepage id: %s", id)
-	logger.Debugf(true, "Space homepage number of children: %d", children)
-	logger.Debugf(true, "Space homepage created: %v", created)
+	logger.Debugf(false, "Space homepage id: %s", id)
+	logger.Debugf(false, "Space homepage number of children: %d", children)
+	logger.Debugf(false, "Space homepage created: %v", created)
 
 	h := homepage{id: id, created: time.NewTime(created), childless: children == 0, spaceKey: spaceKey, apiClient: a}
 
@@ -38,8 +38,8 @@ func newHomepage(spaceKey string, a api.Client) (homepage, error) {
 // queries required by their Confluence instance - see:
 // https://community.atlassian.com/t5/Confluence-questions/How-do-I-pass-a-UTC-time-as-the-value-of-lastModified-in-a-REST/qaq-p/1557903
 func (h *homepage) cqlTimeOffset() (int, error) {
-	logger.Debugf(true, "Confluence homepage ID is %s for space %s", h.spaceKey, h.id)
-	logger.Debugf(true, "Homepage created at: %v (UTC)", h.created)
+	logger.Debugf(false, "Confluence homepage ID is %s for space %s", h.spaceKey, h.id)
+	logger.Debugf(false, "Homepage created at: %v (UTC)", h.created)
 	// nolint:gomnd
 	minOffset := -12 // the latest time zone on earth, 12 hours behind UTC
 	maxOffset := 14  // the earliest time zone on earth, 14 hours ahead of UTC
@@ -51,7 +51,7 @@ func (h *homepage) cqlTimeOffset() (int, error) {
 			cqlTime := h.created.CQLFormat(o)
 
 			if h.apiClient.WasPageCreatedAt(cqlTime, h.id) {
-				logger.Debugf(true, "Successfully calculated time offset for Confluence CQL searches: UTC %+d hours", o)
+				logger.Debugf(false, "Successfully calculated time offset for Confluence CQL searches: UTC %+d hours", o)
 				offset = o
 				return
 			}

--- a/internal/confluence/space.go
+++ b/internal/confluence/space.go
@@ -42,8 +42,8 @@ func (s *space) setup() error {
 		return err
 	}
 
-	logger.Debugf(true, "Last published: %s", lastPublishedString)
-	logger.Debugf(true, "Last published version: %d", version)
+	logger.Debugf(false, "Last published: %s", lastPublishedString)
+	logger.Debugf(false, "Last published version: %d", version)
 
 	s.lastPublished = time.NewLastPublished(lastPublishedString, version)
 
@@ -81,7 +81,7 @@ func (s *space) setup() error {
 func (s *space) isBlank() (bool, error) {
 	totalPagesInSpace, err := s.apiClient.TotalPagesInSpace(s.key)
 
-	logger.Debugf(true, "Total pages in Confluence space prior to publishing: %d", totalPagesInSpace)
+	logger.Debugf(false, "Total pages in Confluence space prior to publishing: %d", totalPagesInSpace)
 
 	if err != nil {
 		return false, err
@@ -129,7 +129,7 @@ func (s *space) updateLastPublished() error {
 		LastPublished: time.Now().String(),
 	}
 
-	logger.Debugf(true, "updating last published version to: %d", s.lastPublished.Version+1)
+	logger.Debugf(false, "updating last published version to: %d", s.lastPublished.Version+1)
 
 	return s.apiClient.SetContentProperty(s.homepage.id, time.LastPublishedPropertyKey, value, s.lastPublished.Version+1)
 }

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "confluence",
-    "version": "0.10.3",
+    "version": "0.10.4",
     "name": "Confluence",
     "description": "Publishes Gauge specifications to Confluence",
     "install": {


### PR DESCRIPTION
Prior to this commit we were displaying a number of debugging messages
as console output when the plugin was invoked.  This was not ideal as
the messages clutter the console output and would not be helpful to
standard users of the plugin. Users of the plugin no longer see these
messages on the console now.  The messages still appear in the
`gaugeconfluence.log` though, which is what we want.

Fixes #25