### PR TITLE
Add informative console output during publishing

### DIFF
--- a/internal/confluence/publisher.go
+++ b/internal/confluence/publisher.go
@@ -12,6 +12,7 @@ import (
 	"github.com/agilepathway/gauge-confluence/internal/errors"
 	"github.com/agilepathway/gauge-confluence/internal/gauge"
 	"github.com/agilepathway/gauge-confluence/internal/git"
+	"github.com/agilepathway/gauge-confluence/internal/logger"
 )
 
 // Publisher publishes Gauge specifications to Confluence.
@@ -44,11 +45,15 @@ func makeSpecsMap(m *gauge_messages.SpecDetails) map[string]Spec {
 func (p *Publisher) Publish(specPaths []string) {
 	var err error
 
+	logger.Infof(true, "Preparing to publish Gauge specs to Confluence ...")
+
 	err = p.space.setup()
 	if err != nil {
 		p.printFailureMessage(err)
 		return
 	}
+
+	logger.Infof(true, "Publishing Gauge specs to Confluence ...")
 
 	err = p.space.deleteAllPagesExceptHomepage()
 

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "confluence",
-    "version": "0.10.4",
+    "version": "0.11.0",
     "name": "Confluence",
     "description": "Publishes Gauge specifications to Confluence",
     "install": {


### PR DESCRIPTION
This commit adds two simple messages output on the console (and also in
the logs) during publishing, to provide reassurance when running the
plugin that the plugin is working as expected.

Fixes #26