### PR TITLE
Fix error message when Space homepage is missing

### DIFF
--- a/functional-tests/specs/space_validity.spec
+++ b/functional-tests/specs/space_validity.spec
@@ -29,6 +29,14 @@ The Space can have a homepage but no other pages before the first ever publish t
 * The error message "Failed: the space must be empty when you publish for the first time" should be output
 
 
+## Publishing is aborted if the Space does not have a homepage
+
+* Manually delete the Confluence space homepage
+
+* Publish "1" specs to Confluence
+
+* The error message "add a homepage manually in Confluence to the space, then try again" should be output
+
 
 __________________________________________________________________________________________
 

--- a/functional-tests/src/test/java/com/thoughtworks/gauge/test/confluence/Confluence.java
+++ b/functional-tests/src/test/java/com/thoughtworks/gauge/test/confluence/Confluence.java
@@ -19,15 +19,21 @@ public class Confluence {
 
     private static final String SCENARIO_SPACE_KEY_NAME = "confluence-space-key";
     private static final String SCENARIO_SPACE_NAME = "Space";
+    private static final String SCENARIO_SPACE_HOMEPAGE_ID_KEY_NAME = "confluence-space-homepage-id-key";
 
     public static String getScenarioSpaceKey() {
         return (String) ScenarioDataStore.get(SCENARIO_SPACE_KEY_NAME);
     }
 
+    public static String getScenarioSpaceHomepageID() {
+        return (String) ScenarioDataStore.get(SCENARIO_SPACE_HOMEPAGE_ID_KEY_NAME);
+    }
+
     @BeforeScenario
     public void BeforeScenario() {
         ScenarioDataStore.put(SCENARIO_SPACE_KEY_NAME, generateUniqueSpaceKeyName());
-        ConfluenceClient.createSpace(getScenarioSpaceKey(), SCENARIO_SPACE_NAME);
+        String spaceHomepageID = ConfluenceClient.createSpace(getScenarioSpaceKey(), SCENARIO_SPACE_NAME);
+        ScenarioDataStore.put(SCENARIO_SPACE_HOMEPAGE_ID_KEY_NAME, spaceHomepageID);
     }
 
     @AfterScenario
@@ -58,6 +64,11 @@ public class Confluence {
         waitForNextMinuteToStart();
         ConfluenceClient.createPage(getScenarioSpaceKey());
         TimeUnit.SECONDS.sleep(2); // give Confluence time to process the added page
+    }
+
+    @Step("Manually delete the Confluence space homepage")
+    public void manuallyDeleteTheConfluenceSpaceHomepage() {
+       ConfluenceClient.deletePage(getScenarioSpaceHomepageID());
     }
 
     private void waitForNextMinuteToStart() throws InterruptedException {

--- a/functional-tests/src/test/java/com/thoughtworks/gauge/test/confluence/ConfluenceClient.java
+++ b/functional-tests/src/test/java/com/thoughtworks/gauge/test/confluence/ConfluenceClient.java
@@ -14,8 +14,14 @@ import org.json.JSONObject;
 
 public class ConfluenceClient {
 
-    public static void createSpace(String spaceKey, String spaceName) {
-        sendConfluenceRequest(createSpaceRequest(spaceKey, spaceName));
+    /**
+     * 
+     * @return the newly created Space's homepage ID
+     */
+    public static String createSpace(String spaceKey, String spaceName) {
+        HttpResponse<String> rawResponse = sendConfluenceRequest(createSpaceRequest(spaceKey, spaceName));
+        JSONObject jsonResponse = new JSONObject(rawResponse.body());
+        return jsonResponse.getJSONObject("homepage").getString("id");
     }
 
     public static void deleteSpace(String spaceKey) {
@@ -29,7 +35,7 @@ public class ConfluenceClient {
     public static JSONArray getAllPages(String spaceKey) {
         return getResults(getAllPagesRequest(spaceKey));
     }
-
+ 
     public static JSONArray getResults(HttpRequest request) {
         HttpResponse<String> rawResponse = sendConfluenceRequest(request);
         JSONObject jsonResponse = new JSONObject(rawResponse.body());
@@ -37,6 +43,10 @@ public class ConfluenceClient {
     }
     public static void createPage(String spaceKey) {
         sendConfluenceRequest(createPageRequest(spaceKey));
+    }
+
+    public static void deletePage(String pageID) {
+        sendConfluenceRequest(deletePageRequest(pageID));
     }
 
     private static HttpRequest createSpaceRequest(String spaceKey, String spaceName) {
@@ -63,6 +73,14 @@ public class ConfluenceClient {
     private static HttpRequest deleteSpaceRequest(String spaceKey) {
         HttpRequest.Builder builder = baseConfluenceRequest();
         String deleteSpaceURL = String.format("%1$s/%2$s", baseSpaceAPIURL(), spaceKey);
+        builder.uri(URI.create(deleteSpaceURL));
+        builder.DELETE();
+        return builder.build();
+    }
+
+    public static HttpRequest deletePageRequest(String pageID) {
+        HttpRequest.Builder builder = baseConfluenceRequest();
+        String deleteSpaceURL = String.format("%1$s/%2$s", baseContentAPIURL(), pageID);
         builder.uri(URI.create(deleteSpaceURL));
         builder.DELETE();
         return builder.build();

--- a/internal/confluence/homepage.go
+++ b/internal/confluence/homepage.go
@@ -23,11 +23,12 @@ func newHomepage(spaceKey string, a api.Client) (homepage, error) {
 	logger.Debugf(false, "Space homepage number of children: %d", children)
 	logger.Debugf(false, "Space homepage created: %v", created)
 
-	h := homepage{id: id, created: time.NewTime(created), childless: children == 0, spaceKey: spaceKey, apiClient: a}
-
 	if id == "" {
-		return h, fmt.Errorf("could not obtain a homepage ID for space: %s", spaceKey)
+		return homepage{}, fmt.Errorf("the Confluence space with key %s has no homepage - "+
+			"add a homepage manually in Confluence to the space, then try again", spaceKey)
 	}
+
+	h := homepage{id: id, created: time.NewTime(created), childless: children == 0, spaceKey: spaceKey, apiClient: a}
 
 	return h, err
 }

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "confluence",
-    "version": "0.11.0",
+    "version": "0.11.1",
     "name": "Confluence",
     "description": "Publishes Gauge specifications to Confluence",
     "install": {


### PR DESCRIPTION
This commit fixes a bug where a misleading error message was being
displayed when the Confluence Space has no homepage.  The error now
asks the user of the plugin to add a homepage manually to the Confluence
Space and to try again.

In a future merge request we aim to improve how the plugin handles this
scenario, by automatically adding a homepage instead of reporting an
error.  As we like [small atomic commits][1] this commit is the first
step in the right direction here.

[1]: https://tekin.co.uk/2021/01/how-atomic-commits-make-you-a-better-coder