### PR TITLE
Move duplicate title checks to before publishing

### DIFF
--- a/functional-tests/specs/duplicate_scenario_headings.spec
+++ b/functional-tests/specs/duplicate_scenario_headings.spec
@@ -8,14 +8,14 @@ NB the spec filenames are not relevant, it's just the spec headings and the dire
 This table shows examples with two specifications, as there needs to be at least two specs for there to be a
 chance of duplicate spec headings.
 
-   |spec 1 heading|spec 1 path  |spec 2 heading|spec 2 path      |result |message                                       |
-   |--------------|-------------|--------------|-----------------|-------|----------------------------------------------|
-   |one           |specs        |two           |specs            |Success|                                              |
-   |one           |specs/folder |two           |specs/folder     |Success|                                              |
-   |one           |specs/folder1|two           |specs/folder2    |Success|                                              |
-   |same          |specs/folder1|same          |specs/folder2    |Failed |2 specs have the same heading                 |
-   |one           |specs/same   |two           |specs/folder/same|Failed |2 directories have the same name              |
-   |same          |specs/same   |two           |specs            |Failed |A spec heading and directory name are the same|
+   |spec 1 heading|spec 1 path  |spec 2 heading|spec 2 path      |did publishing occur?|message                                       |
+   |--------------|-------------|--------------|-----------------|---------------------|----------------------------------------------|
+   |one           |specs        |two           |specs            |did                  |                                              |
+   |one           |specs/folder |two           |specs/folder     |did                  |                                              |
+   |one           |specs/folder1|two           |specs/folder2    |did                  |                                              |
+   |same          |specs/folder1|same          |specs/folder2    |did not              |2 specs have the same heading                 |
+   |one           |specs/same   |two           |specs/folder/same|did not              |2 directories have the same name              |
+   |same          |specs/same   |two           |specs            |did not              |A spec heading and directory name are the same|
 
 
 ## Publishing to Confluence fails if there are any duplicate spec headings or directory names
@@ -27,7 +27,7 @@ chance of duplicate spec headings.
    |<spec 1 heading>|<spec 1 path>|
    |<spec 2 heading>|<spec 2 path>|
 
-* Output contains <result>
+* publishing <did publishing occur?> occur
 * Output contains <message>
 
 ## Republishing after fixing the duplicate spec headings or directory names works fine
@@ -39,7 +39,7 @@ chance of duplicate spec headings.
    |same   |
    |same   |
 
-* Output contains "Failed: 2 specs have the same heading"
+* publishing "did not" occur
 
 * Publish specs to Confluence:
 
@@ -48,4 +48,4 @@ chance of duplicate spec headings.
    |same same    |
    |but different|
 
-* Output contains "Success"
+* publishing "did" occur

--- a/functional-tests/src/test/java/com/thoughtworks/gauge/test/confluence/Confluence.java
+++ b/functional-tests/src/test/java/com/thoughtworks/gauge/test/confluence/Confluence.java
@@ -42,7 +42,7 @@ public class Confluence {
     }
 
     @Step("Published pages are: <table>")
-    public void createSpec(Table expectedPages) throws Exception {
+    public void assertPublishedPages(Table expectedPages) throws Exception {
         int expectedTotal = expectedPages.getTableRows().size();
         assertConsoleSuccessOutput(expectedTotal - 1); // don't count the homepage as we don't publish it
         Space space = new Space(getScenarioSpaceKey());
@@ -50,6 +50,19 @@ public class Confluence {
         for (TableRow row : expectedPages.getTableRows()) {
             String actualParentPageTitle = space.getParentPageTitle(row.getCell("title"));
             assertThat(actualParentPageTitle).isEqualTo(row.getCell("parent"));
+        }
+    }
+
+    @Step("publishing <did or did not> occur")
+    public void didPublishingOccur(String didPublishingOccur) throws IOException {
+        boolean publishingOccurred = (didPublishingOccur.equalsIgnoreCase("did"));
+        Space space = new Space(getScenarioSpaceKey());
+        if (publishingOccurred) {
+            new Console().outputContains("Success: published");
+            assertThat(space.totalPages()).isGreaterThan(1);
+        } else {
+            new Console().outputContains("Failed");
+            assertThat(space.totalPages()).isEqualTo(1);
         }
     }
 

--- a/functional-tests/src/test/java/com/thoughtworks/gauge/test/confluence/ConfluenceClient.java
+++ b/functional-tests/src/test/java/com/thoughtworks/gauge/test/confluence/ConfluenceClient.java
@@ -88,7 +88,7 @@ public class ConfluenceClient {
 
     private static HttpRequest getAllPagesRequest(String spaceKey) {
         HttpRequest.Builder builder = baseConfluenceRequest();
-        String getAllPagesURL = String.format("%1$s?spaceKey=%2$s&expand=ancestors", baseContentAPIURL(), spaceKey);
+        String getAllPagesURL = String.format("%1$s?spaceKey=%2$s&type=page&expand=ancestors", baseContentAPIURL(), spaceKey);
         builder.uri(URI.create(getAllPagesURL));
         return builder.build();
     }

--- a/internal/confluence/space.go
+++ b/internal/confluence/space.go
@@ -101,17 +101,6 @@ func (s *space) parentPageIDFor(path string) string {
 	return parentPageID
 }
 
-// checkForDuplicateTitle returns an error if the given page has the same title as an already published page.
-func (s *space) checkForDuplicateTitle(given page) error {
-	for _, p := range s.publishedPages {
-		if p.title == given.title {
-			return &duplicatePageError{p, given}
-		}
-	}
-
-	return nil
-}
-
 // Value contains the LastPublished time
 type Value struct {
 	LastPublished string `json:"lastPublished"`

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "confluence",
-    "version": "0.11.1",
+    "version": "0.12.0",
     "name": "Confluence",
     "description": "Publishes Gauge specifications to Confluence",
     "install": {


### PR DESCRIPTION
This commit means that we now fail fast (before publishing) if there are
any duplicate page titles.  This is a good thing as prior to this we
were aborting abruptly during publishing if we encountered a duplicate,
meaning that the Confluence space was left in a half-published state.