### PR TITLE
Add dry run mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ If you find a problem with a particular version of Confluence, please
 
 ### Plugin setup
 
-There are four mandatory variables to configure, as either:
+There are four mandatory variables and two optional variables to configure, as either:
 
 1. environment variables
 
@@ -92,7 +92,7 @@ There are four mandatory variables to configure, as either:
    [properties file](https://docs.gauge.org/configuration.html#local-configuration-of-gauge-default-properties),
    e.g. `<project_root>/env/default/anythingyoulike.properties`
 
-The four variables to configure are:
+The four mandatory variables to configure are:
 
 `CONFLUENCE_BASE_URL` e.g. `https://example.com/path-to-your-confluence-wiki` for Confluence Server, or `https://example.atlassian.net` for Confluence Cloud
 
@@ -109,9 +109,23 @@ NB You can use [Confluence's include macro](https://confluence.atlassian.com/doc
 to include the [page tree](https://confluence.atlassian.com/conf59/page-tree-macro-792499177.html) of Gauge Specs
 (that gets created by this plugin) in as many of your existing spaces as you like.
 
-There is also an optional `GAUGE_LOG_LEVEL` variable which can be set to `debug` or `info` (default is`info`).
+The two optional variables to configure are:
+
+`GAUGE_LOG_LEVEL`
+
+`DRY_RUN`
+
+The `GAUGE_LOG_LEVEL` variable can be set to `debug` or `info` (default is `info`).
 It controls the logging level both for the log files which are generated, _and_ what is logged to the console.
 NB the command line flag `--log-level` does not have any effect on the logging for this plugin.
+
+
+**Setting the `DRY_RUN` variable to true means that running the plugin does not publish specs to Confluence.**
+
+Instead the plugin just checks that the specs are in a valid publishable state (e.g. that there are no duplicate
+spec headings).
+This is very useful e.g. **in a CI/CD pipeline the plugin can run in dry run mode on feature branches and pull
+requests.** This ensures that the Gauge specs are always in good shape to be automatically published by the CI/CD pipeline upon any push to the trunk branch (e.g. upon a successful pull request merge).
 
 
 ### Running the plugin (i.e. publishing specs to Confluence)

--- a/functional-tests/specs/dry_run.spec
+++ b/functional-tests/specs/dry_run.spec
@@ -1,0 +1,37 @@
+# Dry run mode
+
+Having a dry run mode is very useful, e.g. in a CI/CD pipeline the dry run mode can be run on feature branches and pull
+requests to verify that the Gauge specs are in a valid state for publishing.  If they are not valid then the CI/CD 
+pipeline build can fail, alerting the submitter of the pull request to amend them on the feature branch.  This ensures
+that the Gauge specs are always in good shape to be automatically published by the CI/CD pipeline upon any push to the 
+trunk branch (e.g. upon a successful pull request merge).
+
+The dry run mode is set by setting a `DRY_RUN` [environment variable or property][2] (we can't use a command-line flag 
+for this as [Gauge does not propagate command line flags to documentation plugins][1]).
+
+
+   |spec 1 heading|spec 2 heading|did publishing occur?|message                            |
+   |--------------|--------------|---------------------|-----------------------------------|
+   |same          |same          |did not              |Please fix the error then try again|
+   |same          |different     |did not              |Dry run finished successfully      |
+
+
+## Dry run mode indicates if specs are in a publishable state or not
+
+* Activate dry run mode
+
+* Publish specs to Confluence:
+
+   |heading         |
+   |----------------|
+   |<spec 1 heading>|
+   |<spec 2 heading>|
+
+* Output contains <message>
+
+* publishing <did publishing occur?> occur
+
+__________________________________________________________________________________________
+
+[1]: https://docs.gauge.org/configuration.html
+[2]: https://github.com/getgauge/spectacle/issues/42#issuecomment-813483933

--- a/functional-tests/src/test/java/com/thoughtworks/gauge/test/common/GaugeProject.java
+++ b/functional-tests/src/test/java/com/thoughtworks/gauge/test/common/GaugeProject.java
@@ -248,6 +248,9 @@ public abstract class GaugeProject {
             throws Exception {
         if (!envVars.containsKey("CONFLUENCE_SPACE_KEY"))
             envVars.put("CONFLUENCE_SPACE_KEY", (String) Confluence.getScenarioSpaceKey());
+        if (Confluence.isDryRun()) {
+            envVars.put("DRY_RUN", "true");
+        }
         boolean success = executeGaugeCommand(args, envVars);
         return new ExecutionSummary(String.join(" ", args), success, lastProcessStdout, lastProcessStderr);
     }

--- a/functional-tests/src/test/java/com/thoughtworks/gauge/test/confluence/Confluence.java
+++ b/functional-tests/src/test/java/com/thoughtworks/gauge/test/confluence/Confluence.java
@@ -20,6 +20,7 @@ public class Confluence {
     private static final String SCENARIO_SPACE_KEY_NAME = "confluence-space-key";
     private static final String SCENARIO_SPACE_NAME = "Space";
     private static final String SCENARIO_SPACE_HOMEPAGE_ID_KEY_NAME = "confluence-space-homepage-id-key";
+    private static final String DRY_RUN_MODE = "dry-run-mode";
 
     public static String getScenarioSpaceKey() {
         return (String) ScenarioDataStore.get(SCENARIO_SPACE_KEY_NAME);
@@ -29,16 +30,26 @@ public class Confluence {
         return (String) ScenarioDataStore.get(SCENARIO_SPACE_HOMEPAGE_ID_KEY_NAME);
     }
 
+    public static boolean isDryRun() {
+        return (boolean) ScenarioDataStore.get(DRY_RUN_MODE);
+    }
+
     @BeforeScenario
     public void BeforeScenario() {
         ScenarioDataStore.put(SCENARIO_SPACE_KEY_NAME, generateUniqueSpaceKeyName());
         String spaceHomepageID = ConfluenceClient.createSpace(getScenarioSpaceKey(), SCENARIO_SPACE_NAME);
         ScenarioDataStore.put(SCENARIO_SPACE_HOMEPAGE_ID_KEY_NAME, spaceHomepageID);
+        ScenarioDataStore.put(DRY_RUN_MODE, false);
     }
 
     @AfterScenario
     public void AfterScenario() {
         ConfluenceClient.deleteSpace(getScenarioSpaceKey());
+    }
+
+    @Step("Activate dry run mode")
+    public void activateDryRunMode() {
+        ScenarioDataStore.put(DRY_RUN_MODE, true);
     }
 
     @Step("Published pages are: <table>")
@@ -61,7 +72,7 @@ public class Confluence {
             new Console().outputContains("Success: published");
             assertThat(space.totalPages()).isGreaterThan(1);
         } else {
-            new Console().outputContains("Failed");
+            new Console().outputDoesNotContain("Success: published");
             assertThat(space.totalPages()).isEqualTo(1);
         }
     }

--- a/functional-tests/src/test/java/com/thoughtworks/gauge/test/implementation/Console.java
+++ b/functional-tests/src/test/java/com/thoughtworks/gauge/test/implementation/Console.java
@@ -15,6 +15,12 @@ public class Console {
         assertThat(output).contains(message);
     }
 
+    @Step("Output doesNotContain <message>")
+    public void outputDoesNotContain(String message) throws IOException {
+        String output = getCurrentProject().getStdOut();
+        assertThat(output).doesNotContain(message);
+    }
+
     @Step({ "Output contains <message> <message2> <message3>" })
     public void outputContainsMessages(String message, String message2, String message3) throws IOException {
         String output = getCurrentProject().getStdOut();

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -4,6 +4,7 @@ package env
 import (
 	"fmt"
 	"os"
+	"strings"
 )
 
 // GetRequired returns an environment variable value or panics if not present.
@@ -15,4 +16,10 @@ func GetRequired(key string) string {
 	}
 
 	return value
+}
+
+// GetBoolean returns true if the environment variable exists and has a value of "true"
+func GetBoolean(key string) bool {
+	value := os.Getenv(key)
+	return strings.ToLower(value) == "true"
 }

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "confluence",
-    "version": "0.12.0",
+    "version": "0.13.0",
     "name": "Confluence",
     "description": "Publishes Gauge specifications to Confluence",
     "install": {


### PR DESCRIPTION
Having a dry run mode is very useful, e.g. in a CI/CD pipeline the dry
run mode can be run on feature branches and pull requests to verify that
the Gauge specs are in a valid state for publishing.  If they are not
valid then the CI/CD pipeline build can fail, alerting the submitter
of the pull request to amend them on the feature branch.  This ensures
that the Gauge specs are always in good shape to be automatically
published by the CI/CD pipeline upon any push to the trunk branch (e.g.
upon a successful pull request merge).

The dry run mode is set by setting a `DRY_RUN` environment variable
or property (we can't use a command-line flag for this as [Gauge does
not propagate command line flags to documentation plugins][1]).

[1]: https://github.com/getgauge/spectacle/issues/42#issuecomment-813483933