### PR TITLE
Improve dry run documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ It controls the logging level both for the log files which are generated, _and_ 
 NB the command line flag `--log-level` does not have any effect on the logging for this plugin.
 
 
-**Setting the `DRY_RUN` variable to true means that running the plugin does not publish specs to Confluence.**
+**Setting the `DRY_RUN` variable to `true` means that running the plugin does not publish specs to Confluence.**
 
 Instead the plugin just checks that the specs are in a valid publishable state (e.g. that there are no duplicate
 spec headings).

--- a/functional-tests/specs/dry_run.spec
+++ b/functional-tests/specs/dry_run.spec
@@ -6,8 +6,8 @@ pipeline build can fail, alerting the submitter of the pull request to amend the
 that the Gauge specs are always in good shape to be automatically published by the CI/CD pipeline upon any push to the 
 trunk branch (e.g. upon a successful pull request merge).
 
-The dry run mode is set by setting a `DRY_RUN` [environment variable or property][2] (we can't use a command-line flag 
-for this as [Gauge does not propagate command line flags to documentation plugins][1]).
+The dry run mode is set by setting a `DRY_RUN` [environment variable or property][2] with the value `true` (we can't
+use a command-line flag for this as [Gauge does not propagate command line flags to documentation plugins][1]).
 
 
    |spec 1 heading|spec 2 heading|did publishing occur?|message                            |

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "confluence",
-    "version": "0.13.0",
+    "version": "0.13.1",
     "name": "Confluence",
     "description": "Publishes Gauge specifications to Confluence",
     "install": {


### PR DESCRIPTION
This is a very small documentation improvement (we now make it clear
that the `DRY_RUN` configuration variable needs to be set to `true` to 
activate dry run mode).