### PR TITLE
Remove need for space in dry run mode

### DIFF
--- a/functional-tests/specs/check_config_vars.spec
+++ b/functional-tests/specs/check_config_vars.spec
@@ -1,4 +1,5 @@
 # Configuration variables are required to be set
+Tags: create-space-manually
 
    |config variable     |
    |--------------------|

--- a/functional-tests/specs/delete_specs_before_publishing.spec
+++ b/functional-tests/specs/delete_specs_before_publishing.spec
@@ -1,4 +1,5 @@
 # Delete existing published specs before publishing
+Tags: create-space-manually
 
 ## The plugin deletes all existing published specs before publishing
 It is safe to do this as before doing so we abort if the Space has been manually edited since the last publish.

--- a/functional-tests/specs/do_not_publish_concepts.spec
+++ b/functional-tests/specs/do_not_publish_concepts.spec
@@ -1,5 +1,5 @@
 # Concepts are not published
-
+Tags: create-space-manually
 
 ## Concepts are not published
 

--- a/functional-tests/specs/dry_run.spec
+++ b/functional-tests/specs/dry_run.spec
@@ -36,6 +36,18 @@ Tags: create-space-manually
 
 * Specs "did not" get published
 
+
+## Dry run mode does not require the Confluence Space to exist yet
+The absence of the "create-space-manually" tag means the Confluence Space does not
+exist for this scenario
+
+* Activate dry run mode
+
+* Publish "1" specs to Confluence
+
+* Output contains "Dry run finished successfully"
+
+
 __________________________________________________________________________________________
 
 [1]: https://docs.gauge.org/configuration.html

--- a/functional-tests/specs/dry_run.spec
+++ b/functional-tests/specs/dry_run.spec
@@ -21,6 +21,7 @@ use a command-line flag for this as [Gauge does not propagate command line flags
 
 
 ## Dry run mode indicates if specs are in a publishable state or not
+Tags: create-space-manually
 
 * Activate dry run mode
 

--- a/functional-tests/specs/duplicate_scenario_headings.spec
+++ b/functional-tests/specs/duplicate_scenario_headings.spec
@@ -1,4 +1,6 @@
 # Duplicate spec headings and directory names
+Tags: create-space-manually
+
 The page title for every page in a Confluence space must be unique.
 We use the specification heading as the Confluence page title.
 And for directories we use the directory name as the Confluence page title.

--- a/functional-tests/specs/publish_specs.spec
+++ b/functional-tests/specs/publish_specs.spec
@@ -1,4 +1,5 @@
 # End to end example
+Tags: create-space-manually
 
 ## All specs are published, including those in subdirectories
 The specs are published to Confluence as a page tree, mirroring the directory structure of the specs.  This means that

--- a/functional-tests/specs/space_validity.spec
+++ b/functional-tests/specs/space_validity.spec
@@ -1,4 +1,6 @@
 # Confluence Space validity
+Tags: create-space-manually
+
 This Gauge Confluence plugin requires that the specs for a given Gauge project are published to
 their own dedicated [Confluence Space][1], with no manual edits or additions in Confluence.
 Having the Space only contain published Gauge specs ensures that there is no danger of the plugin

--- a/functional-tests/specs/spec_validity.spec
+++ b/functional-tests/specs/spec_validity.spec
@@ -1,4 +1,5 @@
 # Spec validity for publishing to Confluence
+Tags: create-space-manually
 
 ## Specs without a heading are not published to Confluence
 

--- a/functional-tests/src/test/java/com/thoughtworks/gauge/test/confluence/Confluence.java
+++ b/functional-tests/src/test/java/com/thoughtworks/gauge/test/confluence/Confluence.java
@@ -13,6 +13,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.IOException;
 import java.time.LocalTime;
 import java.util.concurrent.TimeUnit;
+import java.util.Objects;
 import java.util.UUID;
 
 public class Confluence {
@@ -23,7 +24,7 @@ public class Confluence {
     private static final String DRY_RUN_MODE = "dry-run-mode";
 
     public static String getScenarioSpaceKey() {
-        return (String) ScenarioDataStore.get(SCENARIO_SPACE_KEY_NAME);
+        return Objects.toString(ScenarioDataStore.get(SCENARIO_SPACE_KEY_NAME), "");
     }
 
     public static String getScenarioSpaceHomepageID() {
@@ -34,16 +35,20 @@ public class Confluence {
         return (boolean) ScenarioDataStore.get(DRY_RUN_MODE);
     }
 
-    @BeforeScenario(tags = {"create-space-manually"})
-    public void beforeScenario() {
-        ScenarioDataStore.put(SCENARIO_SPACE_KEY_NAME, generateUniqueSpaceKeyName());
-        String spaceHomepageID = ConfluenceClient.createSpace(getScenarioSpaceKey(), SCENARIO_SPACE_NAME);
-        ScenarioDataStore.put(SCENARIO_SPACE_HOMEPAGE_ID_KEY_NAME, spaceHomepageID);
-    }
-
     @BeforeScenario
     public void setDryRunModeOff() {
         ScenarioDataStore.put(DRY_RUN_MODE, false);
+    }
+
+    @BeforeScenario
+    public void setSpaceKeyName() {
+        ScenarioDataStore.put(SCENARIO_SPACE_KEY_NAME, generateUniqueSpaceKeyName());
+    }
+
+    @BeforeScenario(tags = {"create-space-manually"})
+    public void beforeScenario() {
+        String spaceHomepageID = ConfluenceClient.createSpace(getScenarioSpaceKey(), SCENARIO_SPACE_NAME);
+        ScenarioDataStore.put(SCENARIO_SPACE_HOMEPAGE_ID_KEY_NAME, spaceHomepageID);
     }
 
     @AfterScenario(tags = {"create-space-manually"})

--- a/functional-tests/src/test/java/com/thoughtworks/gauge/test/confluence/Confluence.java
+++ b/functional-tests/src/test/java/com/thoughtworks/gauge/test/confluence/Confluence.java
@@ -34,16 +34,20 @@ public class Confluence {
         return (boolean) ScenarioDataStore.get(DRY_RUN_MODE);
     }
 
-    @BeforeScenario
-    public void BeforeScenario() {
+    @BeforeScenario(tags = {"create-space-manually"})
+    public void beforeScenario() {
         ScenarioDataStore.put(SCENARIO_SPACE_KEY_NAME, generateUniqueSpaceKeyName());
         String spaceHomepageID = ConfluenceClient.createSpace(getScenarioSpaceKey(), SCENARIO_SPACE_NAME);
         ScenarioDataStore.put(SCENARIO_SPACE_HOMEPAGE_ID_KEY_NAME, spaceHomepageID);
+    }
+
+    @BeforeScenario
+    public void setDryRunModeOff() {
         ScenarioDataStore.put(DRY_RUN_MODE, false);
     }
 
-    @AfterScenario
-    public void AfterScenario() {
+    @AfterScenario(tags = {"create-space-manually"})
+    public void afterScenario() {
         ConfluenceClient.deleteSpace(getScenarioSpaceKey());
     }
 

--- a/internal/confluence/publisher.go
+++ b/internal/confluence/publisher.go
@@ -47,11 +47,6 @@ func makeSpecsMap(m *gauge_messages.SpecDetails) map[string]Spec {
 func (p *Publisher) Publish(specPaths []string) (err error) {
 	logger.Infof(true, "Checking specs are in a valid state for publishing to Confluence ...")
 
-	err = p.space.setup()
-	if err != nil {
-		return err
-	}
-
 	for _, specPath := range specPaths {
 		err = p.dryRunChecks(specPath)
 		if err != nil {
@@ -66,6 +61,11 @@ func (p *Publisher) Publish(specPaths []string) (err error) {
 
 	logger.Infof(true, "Checking finished successfully")
 	logger.Infof(true, "Publishing Gauge specs to Confluence ...")
+
+	err = p.space.setup()
+	if err != nil {
+		return err
+	}
 
 	err = p.space.deleteAllPagesExceptHomepage()
 

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "confluence",
-    "version": "0.13.3",
+    "version": "0.13.4",
     "name": "Confluence",
     "description": "Publishes Gauge specifications to Confluence",
     "install": {


### PR DESCRIPTION
Move space setup to after pre-publish checks.

This means that the dry-run mode is guaranteed not to have side-effects
as there is no interaction at all with the Confluence Space during the
pre-publish checks.  It also means that the Confluence Space does not
need to exist when running in dry-run mode, which is useful to help
people get started in trying out the plugin.