### PR TITLE
Create space if it does not already exist

### DIFF
--- a/functional-tests/scripts/manage_space.spec
+++ b/functional-tests/scripts/manage_space.spec
@@ -12,4 +12,4 @@ These specs are just helper functions - they do not document or exercise the Gau
 * Delete all spaces named "Change me to the name of the space you want to delete"
 
 ## Print space content
-* Print content for space with key "Change me to the name of the space you want to print the contents of"
+* Print space with key "Change me to the name of the space you want to print the contents of"

--- a/functional-tests/specs/dry_run.spec
+++ b/functional-tests/specs/dry_run.spec
@@ -41,11 +41,15 @@ Tags: create-space-manually
 The absence of the "create-space-manually" tag means the Confluence Space does not
 exist for this scenario
 
+* Space does not exist
+
 * Activate dry run mode
 
 * Publish "1" specs to Confluence
 
 * Output contains "Dry run finished successfully"
+
+* Space does not exist
 
 
 __________________________________________________________________________________________

--- a/functional-tests/specs/space_creation.spec
+++ b/functional-tests/specs/space_creation.spec
@@ -7,3 +7,5 @@
 * Publish "1" specs to Confluence
 
 * Specs "did" get published
+
+* Space has name "Gauge specs for https://github.com/agilepathway/gauge-confluence"

--- a/functional-tests/specs/space_creation.spec
+++ b/functional-tests/specs/space_creation.spec
@@ -1,0 +1,9 @@
+# Confluence Space creation
+
+## If the Space does not already exist, the plugin will create it
+The absence of the "create-space-manually" tag means the Confluence Space does not
+already exist for this scenario.
+
+* Publish "1" specs to Confluence
+
+* Specs "did" get published

--- a/functional-tests/specs/space_creation.spec
+++ b/functional-tests/specs/space_creation.spec
@@ -8,4 +8,13 @@
 
 * Specs "did" get published
 
-* Space has name "Gauge specs for https://github.com/agilepathway/gauge-confluence"
+* Space has name "Gauge specs for example-user/example-repo"
+
+The `example-user/example-repo` comes from the [dummy Git remote URL config in the
+test framework code][1].  When users run the plugin the Space name will be taken from 
+the Git remote URL of the Git repository that the plugin is executed on.
+
+
+__________________________________________________________________________________________
+
+[1]: https://github.com/agilepathway/gauge-confluence/blob/ae3129705ef85eaf56846d26b49e968de8b70e8b/functional-tests/src/test/java/com/thoughtworks/gauge/test/git/Config.java

--- a/functional-tests/specs/space_creation.spec
+++ b/functional-tests/specs/space_creation.spec
@@ -1,8 +1,8 @@
 # Confluence Space creation
 
 ## If the Space does not already exist, the plugin will create it
-The absence of the "create-space-manually" tag means the Confluence Space does not
-already exist for this scenario.
+
+* Space does not exist
 
 * Publish "1" specs to Confluence
 

--- a/functional-tests/src/test/java/com/thoughtworks/gauge/test/confluence/Confluence.java
+++ b/functional-tests/src/test/java/com/thoughtworks/gauge/test/confluence/Confluence.java
@@ -61,6 +61,11 @@ public class Confluence {
         ScenarioDataStore.put(DRY_RUN_MODE, true);
     }
 
+    @Step("Space does not exist")
+    public void assertSpaceDoesNotExist() {
+        assertThat(ConfluenceClient.doesSpaceExist(getScenarioSpaceKey())).isFalse();
+    }
+
     @Step("Published pages are: <table>")
     public void assertPublishedPages(Table expectedPages) throws Exception {
         int expectedTotal = expectedPages.getTableRows().size();

--- a/functional-tests/src/test/java/com/thoughtworks/gauge/test/confluence/Confluence.java
+++ b/functional-tests/src/test/java/com/thoughtworks/gauge/test/confluence/Confluence.java
@@ -66,14 +66,20 @@ public class Confluence {
         assertThat(ConfluenceClient.doesSpaceExist(getScenarioSpaceKey())).isFalse();
     }
 
+    @Step("Space has name <name>")
+    public void assertSpaceHasName(String name) {
+        Space space = new Space(getScenarioSpaceKey());
+        assertThat(space.getName()).isEqualTo(name);
+    }
+
     @Step("Published pages are: <table>")
     public void assertPublishedPages(Table expectedPages) throws Exception {
         int expectedTotal = expectedPages.getTableRows().size();
         assertConsoleSuccessOutput(expectedTotal - 1); // don't count the homepage as we don't publish it
-        Space space = new Space(getScenarioSpaceKey());
-        assertThat(space.totalPages()).isEqualTo(expectedTotal);
+        SpacePages spacePages = new SpacePages(getScenarioSpaceKey());
+        assertThat(spacePages.total()).isEqualTo(expectedTotal);
         for (TableRow row : expectedPages.getTableRows()) {
-            String actualParentPageTitle = space.getParentPageTitle(row.getCell("title"));
+            String actualParentPageTitle = spacePages.getParentPageTitle(row.getCell("title"));
             assertThat(actualParentPageTitle).isEqualTo(row.getCell("parent"));
         }
     }
@@ -81,13 +87,13 @@ public class Confluence {
     @Step("Specs <did|did not> get published")
     public void didPublishingOccur(String didPublishingOccur) throws IOException {
         boolean publishingOccurred = (didPublishingOccur.equalsIgnoreCase("did"));
-        Space space = new Space(getScenarioSpaceKey());
+        SpacePages spacePages = new SpacePages(getScenarioSpaceKey());
         if (publishingOccurred) {
             new Console().outputContains("Success: published");
-            assertThat(space.totalPages()).isGreaterThan(1);
+            assertThat(spacePages.total()).isGreaterThan(1);
         } else {
             new Console().outputDoesNotContain("Success: published");
-            assertThat(space.totalPages()).isEqualTo(1);
+            assertThat(spacePages.total()).isEqualTo(1);
         }
     }
 

--- a/functional-tests/src/test/java/com/thoughtworks/gauge/test/confluence/ConfluenceClient.java
+++ b/functional-tests/src/test/java/com/thoughtworks/gauge/test/confluence/ConfluenceClient.java
@@ -41,15 +41,28 @@ public class ConfluenceClient {
         return getResults(getAllSpacesRequest());
     }
 
+    public static JSONObject getSpace(String spaceKey) {
+        return getJSONResponse(getSpaceRequest(spaceKey));
+    }
+
+    public static JSONObject getSpaceWithAllPages(String spaceKey) {
+        return getJSONResponse(getAllPagesRequest(spaceKey));
+    }
+
     public static JSONArray getAllPages(String spaceKey) {
         return getResults(getAllPagesRequest(spaceKey));
     }
+
+    public static JSONObject getJSONResponse(HttpRequest request) {
+        HttpResponse<String> rawResponse = sendConfluenceRequest(request);
+        return new JSONObject(rawResponse.body());
+    }
  
     public static JSONArray getResults(HttpRequest request) {
-        HttpResponse<String> rawResponse = sendConfluenceRequest(request);
-        JSONObject jsonResponse = new JSONObject(rawResponse.body());
+        JSONObject jsonResponse = getJSONResponse(request);
         return (JSONArray) jsonResponse.get("results");
     }
+
     public static void createPage(String spaceKey) {
         sendConfluenceRequest(createPageRequest(spaceKey));
     }
@@ -104,7 +117,7 @@ public class ConfluenceClient {
 
     private static HttpRequest getSpaceRequest(String spaceKey) {
         HttpRequest.Builder builder = baseConfluenceRequest();
-        String getSpaceURL = String.format("%1$s/%2$s", baseContentAPIURL(), spaceKey);
+        String getSpaceURL = String.format("%1$s/%2$s", baseSpaceAPIURL(), spaceKey);
         builder.uri(URI.create(getSpaceURL));
         return builder.build();
     }

--- a/functional-tests/src/test/java/com/thoughtworks/gauge/test/confluence/ConfluenceClient.java
+++ b/functional-tests/src/test/java/com/thoughtworks/gauge/test/confluence/ConfluenceClient.java
@@ -24,6 +24,15 @@ public class ConfluenceClient {
         return jsonResponse.getJSONObject("homepage").getString("id");
     }
 
+    public static boolean doesSpaceExist(String spaceKey) {
+        try {
+            sendConfluenceRequest(getSpaceRequest(spaceKey));
+            return true;
+        } catch (IllegalStateException e) {
+            return false;
+        }
+    }
+
     public static void deleteSpace(String spaceKey) {
         sendConfluenceRequest(deleteSpaceRequest(spaceKey));
     }
@@ -90,6 +99,13 @@ public class ConfluenceClient {
         HttpRequest.Builder builder = baseConfluenceRequest();
         String getAllPagesURL = String.format("%1$s?spaceKey=%2$s&type=page&expand=ancestors", baseContentAPIURL(), spaceKey);
         builder.uri(URI.create(getAllPagesURL));
+        return builder.build();
+    }
+
+    private static HttpRequest getSpaceRequest(String spaceKey) {
+        HttpRequest.Builder builder = baseConfluenceRequest();
+        String getSpaceURL = String.format("%1$s/%2$s", baseContentAPIURL(), spaceKey);
+        builder.uri(URI.create(getSpaceURL));
         return builder.build();
     }
 

--- a/functional-tests/src/test/java/com/thoughtworks/gauge/test/confluence/Space.java
+++ b/functional-tests/src/test/java/com/thoughtworks/gauge/test/confluence/Space.java
@@ -13,5 +13,10 @@ public class Space {
     public String getName() {
         return jsonSpace.getString("name");
     }
+
+    @Override
+    public String toString() {
+        return jsonSpace.toString(4);
+    }
     
 }

--- a/functional-tests/src/test/java/com/thoughtworks/gauge/test/confluence/Space.java
+++ b/functional-tests/src/test/java/com/thoughtworks/gauge/test/confluence/Space.java
@@ -1,56 +1,17 @@
 package com.thoughtworks.gauge.test.confluence;
 
-import org.json.JSONArray;
 import org.json.JSONObject;
 
 public class Space {
 
-    private JSONArray pages;
+    private JSONObject jsonSpace;
 
     public Space(String key) {
-        this.pages = ConfluenceClient.getAllPages(key);
+        this.jsonSpace = ConfluenceClient.getSpace(key);
     }
 
-    public String getParentPageTitle(String title) {
-        String parentPageID = getParentPageID(title);
-        if (parentPageID.isEmpty())
-            return "";
-        JSONObject parentPage = getPageByID(parentPageID);
-        return parentPage.getString("title");
+    public String getName() {
+        return jsonSpace.getString("name");
     }
-
-    private String getParentPageID(String title) {
-        JSONObject page = getPageByTitle(title);
-        JSONArray ancestors = page.getJSONArray("ancestors");
-        if (ancestors.isEmpty())
-            return "";
-        JSONObject parent = ancestors.getJSONObject(ancestors.length() - 1);
-
-        return parent.getString("id");
-    }
-
-    private JSONObject getPageByID(String pageID) {
-        for (int i = 0; i < pages.length(); i++) {
-            JSONObject page = pages.getJSONObject(i);
-            if (page.getString("id").equals(pageID)) {
-                return page;
-            }
-        }
-        throw new IllegalStateException("page not found");
-    }
-
-    private JSONObject getPageByTitle(String title) {
-        for (int i = 0; i < pages.length(); i++) {
-            JSONObject page = pages.getJSONObject(i);
-            if (page.getString("title").equals(title)) {
-                return page;
-            }
-        }
-        throw new IllegalStateException("page not found");
-    }
-
-    public int totalPages() {
-        return pages.length();
-    }
-
+    
 }

--- a/functional-tests/src/test/java/com/thoughtworks/gauge/test/confluence/SpaceManager.java
+++ b/functional-tests/src/test/java/com/thoughtworks/gauge/test/confluence/SpaceManager.java
@@ -27,10 +27,10 @@ public class SpaceManager {
         }
     }
 
-    @Step("Print content for space with key <space key>")
-    public void getContentForSpace(String spaceKey) {
-        JSONArray content = ConfluenceClient.getAllPages(spaceKey);
-        System.out.println(content);
+    @Step("Print space with key <space key>")
+    public void printPagesForSpace(String spaceKey) {
+        System.out.println(new Space(spaceKey));
+        System.out.println(new SpacePages(spaceKey));
     }
 
     private void deleteSpaceIfNamed(JSONObject sp, String spaceName) {

--- a/functional-tests/src/test/java/com/thoughtworks/gauge/test/confluence/SpacePages.java
+++ b/functional-tests/src/test/java/com/thoughtworks/gauge/test/confluence/SpacePages.java
@@ -1,0 +1,56 @@
+package com.thoughtworks.gauge.test.confluence;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+public class SpacePages {
+
+    private JSONArray jsonPages;
+
+    public SpacePages(String key) {
+        this.jsonPages = ConfluenceClient.getAllPages(key);
+    }
+
+    public String getParentPageTitle(String title) {
+        String parentPageID = getParentPageID(title);
+        if (parentPageID.isEmpty())
+            return "";
+        JSONObject parentPage = getPageByID(parentPageID);
+        return parentPage.getString("title");
+    }
+
+    private String getParentPageID(String title) {
+        JSONObject page = getPageByTitle(title);
+        JSONArray ancestors = page.getJSONArray("ancestors");
+        if (ancestors.isEmpty())
+            return "";
+        JSONObject parent = ancestors.getJSONObject(ancestors.length() - 1);
+
+        return parent.getString("id");
+    }
+
+    private JSONObject getPageByID(String pageID) {
+        for (int i = 0; i < jsonPages.length(); i++) {
+            JSONObject page = jsonPages.getJSONObject(i);
+            if (page.getString("id").equals(pageID)) {
+                return page;
+            }
+        }
+        throw new IllegalStateException("page not found");
+    }
+
+    private JSONObject getPageByTitle(String title) {
+        for (int i = 0; i < jsonPages.length(); i++) {
+            JSONObject page = jsonPages.getJSONObject(i);
+            if (page.getString("title").equals(title)) {
+                return page;
+            }
+        }
+        throw new IllegalStateException("page not found");
+    }
+
+    public int total() {
+        return jsonPages.length();
+    }
+
+}

--- a/functional-tests/src/test/java/com/thoughtworks/gauge/test/confluence/SpacePages.java
+++ b/functional-tests/src/test/java/com/thoughtworks/gauge/test/confluence/SpacePages.java
@@ -53,4 +53,9 @@ public class SpacePages {
         return jsonPages.length();
     }
 
+    @Override
+    public String toString() {
+        return jsonPages.toString(4);
+    }
+
 }

--- a/internal/confluence/api/client.go
+++ b/internal/confluence/api/client.go
@@ -94,7 +94,7 @@ func (c *Client) DeletePage(pageID string) (err error) {
 }
 
 // CreateSpace creates a Confluence Space with the given key
-func (c *Client) CreateSpace(spaceKey string) error {
+func (c *Client) CreateSpace(key, name string) error {
 	type Data struct {
 		Key  string `json:"key"`
 		Name string `json:"name"`
@@ -102,8 +102,8 @@ func (c *Client) CreateSpace(spaceKey string) error {
 
 	path := "space"
 	requestBody := Data{
-		spaceKey,
-		spaceKey,
+		key,
+		name,
 	}
 
 	return c.httpClient.PostJSON(path, requestBody)

--- a/internal/confluence/api/client.go
+++ b/internal/confluence/api/client.go
@@ -93,6 +93,42 @@ func (c *Client) DeletePage(pageID string) (err error) {
 	return c.httpClient.DeleteContent(pageID)
 }
 
+// CreateSpace creates a Confluence Space with the given key
+func (c *Client) CreateSpace(spaceKey string) error {
+	type Data struct {
+		Key  string `json:"key"`
+		Name string `json:"name"`
+	}
+
+	path := "space"
+	requestBody := Data{
+		spaceKey,
+		spaceKey,
+	}
+
+	return c.httpClient.PostJSON(path, requestBody)
+}
+
+// DoesSpaceExist indicates if the Confluence Space with the given key exists.
+func (c *Client) DoesSpaceExist(spaceKey string) (bool, error) {
+	path := fmt.Sprintf("space/%s", spaceKey)
+
+	var emptyStruct struct{}
+
+	err := c.httpClient.GetJSON(path, &emptyStruct)
+
+	if err != nil {
+		e, ok := err.(*http.RequestError)
+		if ok && e.StatusCode == 404 { //nolint:gomnd
+			return false, nil
+		}
+
+		return false, err
+	}
+
+	return true, nil
+}
+
 // SpaceHomepage provides the page ID, no. of children and created time for the given Space's homepage.
 func (c *Client) SpaceHomepage(spaceKey string) (string, int, string, error) {
 	path := fmt.Sprintf("space?spaceKey=%s&expand=homepage.children.page,homepage.history", spaceKey)

--- a/internal/confluence/api/http/client.go
+++ b/internal/confluence/api/http/client.go
@@ -75,6 +75,39 @@ func (c *Client) httpGet(path string) ([]byte, error) {
 	req, _ := http.NewRequest("GET", url, nil)
 	req.Header.Add("Authorization", "Basic "+c.basicAuth())
 
+	return c.do(req)
+}
+
+func (c *Client) httpPut(path string, requestBody []byte) error {
+	url := fmt.Sprintf("%s/%s", c.restEndpoint, path)
+	req, _ := http.NewRequest("PUT", url, bytes.NewReader(requestBody))
+	req.Header.Set("Content-Type", "application/json; charset=UTF-8")
+	req.Header.Add("Authorization", "Basic "+c.basicAuth())
+	_, err := c.do(req)
+
+	return err
+}
+
+func (c *Client) httpPost(path string, requestBody []byte) error {
+	url := fmt.Sprintf("%s/%s", c.restEndpoint, path)
+	req, _ := http.NewRequest("POST", url, bytes.NewReader(requestBody))
+	req.Header.Set("Content-Type", "application/json; charset=UTF-8")
+	req.Header.Add("Authorization", "Basic "+c.basicAuth())
+	_, err := c.do(req)
+
+	return err
+}
+
+func (c *Client) httpDelete(path string) error {
+	url := fmt.Sprintf("%s/%s", c.restEndpoint, path)
+	req, _ := http.NewRequest("DELETE", url, nil)
+	req.Header.Add("Authorization", "Basic "+c.basicAuth())
+	_, err := c.do(req)
+
+	return err
+}
+
+func (c *Client) do(req *http.Request) ([]byte, error) {
 	response, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, err
@@ -94,84 +127,4 @@ func (c *Client) httpGet(path string) ([]byte, error) {
 	}
 
 	return body, err
-}
-
-func (c *Client) httpPut(path string, requestBody []byte) error {
-	url := fmt.Sprintf("%s/%s", c.restEndpoint, path)
-	req, _ := http.NewRequest("PUT", url, bytes.NewReader(requestBody))
-	req.Header.Set("Content-Type", "application/json; charset=UTF-8")
-	req.Header.Add("Authorization", "Basic "+c.basicAuth())
-
-	response, err := c.httpClient.Do(req)
-	if err != nil {
-		return err
-	}
-
-	if response.Body != nil {
-		defer response.Body.Close() //nolint: errcheck
-	}
-
-	responseBody, err := io.ReadAll(response.Body)
-	if err != nil {
-		return err
-	}
-
-	if response.StatusCode > 299 { //nolint: gomnd
-		return newRequestError(response.StatusCode, string(responseBody))
-	}
-
-	return nil
-}
-
-func (c *Client) httpPost(path string, requestBody []byte) error {
-	url := fmt.Sprintf("%s/%s", c.restEndpoint, path)
-	req, _ := http.NewRequest("POST", url, bytes.NewReader(requestBody))
-	req.Header.Set("Content-Type", "application/json; charset=UTF-8")
-	req.Header.Add("Authorization", "Basic "+c.basicAuth())
-
-	response, err := c.httpClient.Do(req)
-	if err != nil {
-		return err
-	}
-
-	if response.Body != nil {
-		defer response.Body.Close() //nolint: errcheck
-	}
-
-	responseBody, err := io.ReadAll(response.Body)
-	if err != nil {
-		return err
-	}
-
-	if response.StatusCode > 299 { //nolint: gomnd
-		return newRequestError(response.StatusCode, string(responseBody))
-	}
-
-	return nil
-}
-
-func (c *Client) httpDelete(path string) error {
-	url := fmt.Sprintf("%s/%s", c.restEndpoint, path)
-	req, _ := http.NewRequest("DELETE", url, nil)
-	req.Header.Add("Authorization", "Basic "+c.basicAuth())
-	response, err := c.httpClient.Do(req)
-
-	if err != nil {
-		return err
-	}
-
-	if response.Body != nil {
-		defer response.Body.Close() //nolint: errcheck
-	}
-
-	responseBody, err := io.ReadAll(response.Body)
-	if err != nil {
-		return err
-	}
-
-	if response.StatusCode != 204 { //nolint: gomnd
-		return newRequestError(response.StatusCode, string(responseBody))
-	}
-
-	return nil
 }

--- a/internal/confluence/api/http/request_error.go
+++ b/internal/confluence/api/http/request_error.go
@@ -1,0 +1,23 @@
+package http
+
+import (
+	"fmt"
+)
+
+// RequestError encapsulates an HTTP request error, complete with status code.
+type RequestError struct {
+	StatusCode   int
+	ResponseBody string
+}
+
+func (r *RequestError) Error() string {
+	return fmt.Sprintf("HTTP response error: %d %s", r.StatusCode, r.ResponseBody)
+}
+
+// newRequestError creates an HTTP request error, complete with status code.
+func newRequestError(statusCode int, responseBody string) error {
+	return &RequestError{
+		StatusCode:   statusCode,
+		ResponseBody: responseBody,
+	}
+}

--- a/internal/confluence/space.go
+++ b/internal/confluence/space.go
@@ -25,6 +25,11 @@ func newSpace(key string, apiClient api.Client) space {
 }
 
 func (s *space) setup() error {
+	err := s.createIfDoesNotAlreadyExist()
+	if err != nil {
+		return err
+	}
+
 	h, err := newHomepage(s.key, s.apiClient)
 	if err != nil {
 		return err
@@ -76,6 +81,25 @@ func (s *space) setup() error {
 	}
 
 	return nil
+}
+
+func (s *space) createIfDoesNotAlreadyExist() (err error) {
+	spaceExists, err := s.exists()
+	if err != nil {
+		return err
+	}
+
+	if spaceExists {
+		return nil
+	}
+
+	logger.Infof(true, "Space with key %s does not already exist, creating it ...", s.key)
+
+	return s.apiClient.CreateSpace(s.key)
+}
+
+func (s *space) exists() (bool, error) {
+	return s.apiClient.DoesSpaceExist(s.key)
 }
 
 func (s *space) isBlank() (bool, error) {

--- a/internal/confluence/space.go
+++ b/internal/confluence/space.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/agilepathway/gauge-confluence/internal/confluence/api"
 	"github.com/agilepathway/gauge-confluence/internal/confluence/time"
+	"github.com/agilepathway/gauge-confluence/internal/git"
 	"github.com/agilepathway/gauge-confluence/internal/logger"
 )
 
@@ -95,7 +96,21 @@ func (s *space) createIfDoesNotAlreadyExist() (err error) {
 
 	logger.Infof(true, "Space with key %s does not already exist, creating it ...", s.key)
 
-	return s.apiClient.CreateSpace(s.key)
+	spaceName, err := s.name()
+	if err != nil {
+		return err
+	}
+
+	return s.apiClient.CreateSpace(s.key, spaceName)
+}
+
+func (s *space) name() (string, error) {
+	gitRemoteURLPath, err := git.RemoteURLPath()
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("Gauge specs for %s", gitRemoteURLPath), nil
 }
 
 func (s *space) exists() (bool, error) {

--- a/internal/git/git_url_test.go
+++ b/internal/git/git_url_test.go
@@ -55,3 +55,23 @@ func TestBuildGitWebURL(t *testing.T) {
 		}
 	}
 }
+
+var parseURLPathTests = []struct { //nolint:gochecknoglobals
+	input    string
+	expected string
+}{
+	{"http://github.com/example-user/example-repo", "example-user/example-repo"},
+	{"http://github.com:8080/example-user/example-repo", "example-user/example-repo"},
+	{"http://example.com/example-user/example-repo", "example-user/example-repo"},
+	{"https://example.com/example-user/example-repo", "example-user/example-repo"},
+	{"https://example.com/example-user/example-repo/nested", "example-user/example-repo/nested"},
+}
+
+func TestParsePathFromURL(t *testing.T) {
+	for _, tt := range parseURLPathTests {
+		actual, _ := parseURLPath(tt.input)
+		if tt.expected != actual {
+			t.Errorf("parsePathFromURL(%s): expected %s, actual %s", tt.input, tt.expected, actual)
+		}
+	}
+}

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "confluence",
-    "version": "0.13.4",
+    "version": "0.14.0",
     "name": "Confluence",
     "description": "Publishes Gauge specifications to Confluence",
     "install": {


### PR DESCRIPTION
Amongst other benefits, creating the space automatically
if it does not exist makes things easier  for an organisation 
that intends to publish specs from many git repositories to 
Confluence.

NB This PR does not automatically create the Confluence
space key, it still requires the key to be provided by the
user of the plugin as a configuration variable.  In a future
PR we will automatically create the Confluence space key
as well if it is not provided, which will make things easier
still for users of the plugin.