### PR TITLE
Disable tests on Confluence Server temporarily

### DIFF
--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -41,19 +41,13 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        confluence-version: [Cloud, Server]
+        confluence-version: [Cloud]
         include:
           - confluence-version: Cloud
             confluence-base-url: CONFLUENCE_CLOUD_BASE_URL
             confluence-username: CONFLUENCE_CLOUD_USERNAME
             confluence-token: CONFLUENCE_CLOUD_TOKEN
             gauge-tags: "!not-cloud"
-          - confluence-version: Server
-            confluence-base-url: CONFLUENCE_SERVER_BASE_URL
-            confluence-username: CONFLUENCE_SERVER_USERNAME
-            confluence-token: CONFLUENCE_SERVER_TOKEN
-            confluence-username-without-create-space: CONFLUENCE_SERVER_USERNAME_WITHOUT_CREATE_SPACE
-            confluence-token-without-create-space: CONFLUENCE_SERVER_TOKEN_WITHOUT_CREATE_SPACE
             
     steps:
       - name: Set up Go

--- a/functional-tests/build.gradle
+++ b/functional-tests/build.gradle
@@ -29,7 +29,7 @@ languages.each {lang ->
         doFirst {
             gauge {
                 specsDir = 'specs'
-                inParallel = true
+                inParallel = false
             }
         }
     }

--- a/internal/confluence/api/client.go
+++ b/internal/confluence/api/client.go
@@ -193,19 +193,23 @@ func (c *Client) IsSpaceModifiedSinceLastPublished(spaceKey string, lastPublishe
 }
 
 // WasPageCreatedAt returns true if the page was created at the given time.
-func (c *Client) WasPageCreatedAt(cqlTime string, pageID string) bool {
+func (c *Client) WasPageCreatedAt(cqlTime string, pageID string) (bool, error) {
 	query := goconfluence.SearchQuery{
 		CQL: fmt.Sprintf("created=\"%s\" AND ID=\"%s\"", cqlTime, pageID),
 	}
-	result, _ := c.goconfluenceClient.Search(query)
+	result, err := c.goconfluenceClient.Search(query)
+
+	if err != nil {
+		return false, err
+	}
 
 	for _, r := range result.Results {
 		if pageID == r.Content.ID {
-			return true
+			return true, nil
 		}
 	}
 
-	return false
+	return false, nil
 }
 
 // TotalPagesInSpace returns the number of pages (and blogposts) in the given Space

--- a/internal/confluence/homepage.go
+++ b/internal/confluence/homepage.go
@@ -50,11 +50,15 @@ func (h *homepage) cqlTimeOffset() (int, error) {
 	err := errors.Retry(5, 1000, func() (err error) { //nolint:gomnd
 		for o := minOffset; o <= maxOffset; o++ {
 			cqlTime := h.created.CQLFormat(o)
+			wasPageCreatedAtCQLTime, err := h.apiClient.WasPageCreatedAt(cqlTime, h.id)
+			if err != nil {
+				return err
+			}
 
-			if h.apiClient.WasPageCreatedAt(cqlTime, h.id) {
+			if wasPageCreatedAtCQLTime {
 				logger.Debugf(false, "Successfully calculated time offset for Confluence CQL searches: UTC %+d hours", o)
 				offset = o
-				return
+				return nil
 			}
 		}
 		return fmt.Errorf("could not calculate time offset for Confluence CQL searches")

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "confluence",
-    "version": "0.15.0",
+    "version": "0.15.1",
     "name": "Confluence",
     "description": "Publishes Gauge specifications to Confluence",
     "install": {


### PR DESCRIPTION
Up until now we have always run the Continuous Integration tests
against both Confluence Cloud and Confluence Server. There is a
temporary issue with the instance of Confluence Server though (it runs
on Google Cloud Platform and has been mistakenly flagged by Google as
doing Cryptocurrency mining for some reason).  We will reinstate the
tests on Confluence Server as soon as we have a test instance available
again.

There have not been any discrepancies at all between the behaviour on
Confluence Cloud and Confluence Server, which bodes well in terms of
hopefully not finding any errors when we do reinstate Confluence Server.

There is one test to do with Space permissions which we can only run on
Server and not Cloud, so that test will not be run again until we have
Server tests reinstated.