### PR TITLE
Publish the plugin's actual specs via CI/CD

### DIFF
--- a/.github/workflows/publish-specs-to-prod-environment.yml
+++ b/.github/workflows/publish-specs-to-prod-environment.yml
@@ -1,0 +1,53 @@
+---
+name: Publish specs to Confluence production environment
+
+# This GitHub Actions workflow publishes the Gauge specifications for this
+# repository to our Confluence production instance on every push to the
+# master branch, e.g. upon a pull request being successfully merged to master.
+# There is also a separate workflow in another file which publishes the specs
+# to the Confluence test instance on every push to any branch (a feature branch
+# or master).
+
+on:  # yamllint disable-line rule:truthy
+  push:
+    branches:
+      - master
+jobs:
+
+  publish-specs-to-prod-environment:
+    name: Publish Specs to Confluence production environment
+    environment: publish-production
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Install Gauge
+        uses: getgauge/setup-gauge@master
+        with:
+          gauge-plugins: confluence
+
+      - name: Display Gauge version
+        run: |
+          gauge -v
+
+      - name: Dry Run publish specs
+        env:
+          CONFLUENCE_BASE_URL: ${{ secrets.CONFLUENCE_BASE_URL }}
+          CONFLUENCE_USERNAME: ${{ secrets.CONFLUENCE_USERNAME }}
+          CONFLUENCE_TOKEN: ${{ secrets.CONFLUENCE_TOKEN }}
+          DRY_RUN: "true"
+        run: |
+          cd functional-tests
+          gauge docs confluence specs
+
+      - name: Publish specs to Confluence production environment
+        env:
+          CONFLUENCE_BASE_URL: ${{ secrets.CONFLUENCE_BASE_URL }}
+          CONFLUENCE_USERNAME: ${{ secrets.CONFLUENCE_USERNAME }}
+          CONFLUENCE_TOKEN: ${{ secrets.CONFLUENCE_TOKEN }}
+        run: |
+          cd functional-tests
+          gauge docs confluence specs

--- a/.github/workflows/publish-specs-to-test-environment.yml
+++ b/.github/workflows/publish-specs-to-test-environment.yml
@@ -1,0 +1,59 @@
+---
+name: Publish specs to Confluence test environment
+
+# This GitHub Actions workflow publishes the Gauge specifications for this
+# repository to our Confluence test instance, on every push to any branch
+# (both feature branches and the master branch).
+# There is also a separate workflow in another file which publishes the specs
+# to the Confluence production instance on every push to the master branch.
+
+
+on:  # yamllint disable-line rule:truthy
+  push:
+  pull_request:
+    branches:
+      # Branches from forks have the form 'user:branch-name' so we only run
+      # this job on pull_request events for branches that look like fork
+      # branches. Without this we would end up running this job twice for non
+      # forked PRs, once for the push and then once for opening the PR.
+      # See https://github.community/t/how-to-trigger-an-action-on-push-or-pull-request-but-not-both/16662/10
+      - "**:**"
+jobs:
+
+  publish-specs-to-test-environment:
+    name: Publish Specs to Confluence test environment
+    environment: publish-test
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Install Gauge
+        uses: getgauge/setup-gauge@master
+        with:
+          gauge-plugins: confluence
+
+      - name: Display Gauge version
+        run: |
+          gauge -v
+
+      - name: Dry Run publish specs
+        env:
+          CONFLUENCE_BASE_URL: ${{ secrets.CONFLUENCE_BASE_URL }}
+          CONFLUENCE_USERNAME: ${{ secrets.CONFLUENCE_USERNAME }}
+          CONFLUENCE_TOKEN: ${{ secrets.CONFLUENCE_TOKEN }}
+          DRY_RUN: "true"
+        run: |
+          cd functional-tests
+          gauge docs confluence specs
+
+      - name: Publish specs to Confluence test environment
+        env:
+          CONFLUENCE_BASE_URL: ${{ secrets.CONFLUENCE_BASE_URL }}
+          CONFLUENCE_USERNAME: ${{ secrets.CONFLUENCE_USERNAME }}
+          CONFLUENCE_TOKEN: ${{ secrets.CONFLUENCE_TOKEN }}
+        run: |
+          cd functional-tests
+          gauge docs confluence specs

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "confluence",
-    "version": "0.16.0",
+    "version": "0.16.1",
     "name": "Confluence",
     "description": "Publishes Gauge specifications to Confluence",
     "install": {


### PR DESCRIPTION
This commit publishes the plugin's actual Gauge specs so that they can
be viewed on Confluence as living documentation.

Unfortunately the Confluence Space with the published specs cannot
currently be opened up for public access, as [Confluence do not allow
anonymous access on their free plan][1].

On feature branches and pull requests the specs are published to the
test Confluence instance, then on every push to `master` they are
also published to the production Confluence instance as well as to the
test instance (no harm in publishing to test from `master` too, as if
the publishing to production ever fails for some reason it will provide
a useful comparison).

The pipeline code is in two separate workflow files, one for publishing
to the test Confluence instance and one to the production instance.
This has the downside of duplication, but the important upside of using
[GitHub's environment protection rules][2] to give additional
protection against publishing to the production instance from a feature
branch.  The duplication is not large (and is [only in two places][3]),
so the upside outweighs the downside.

[1]: https://support.atlassian.com/confluence-cloud/docs/manage-permissions-in-the-free-edition-of-confluence-cloud/
[2]: https://docs.github.com/en/actions/reference/environments#environment-protection-rules
[3]: https://blog.codinghorror.com/the-delusion-of-reuse/