### PR TITLE
Remove need for Space config vars in dry run mode

### DIFF
--- a/.github/workflows/publish-specs-to-prod-environment.yml
+++ b/.github/workflows/publish-specs-to-prod-environment.yml
@@ -35,9 +35,6 @@ jobs:
 
       - name: Dry Run publish specs
         env:
-          CONFLUENCE_BASE_URL: ${{ secrets.CONFLUENCE_BASE_URL }}
-          CONFLUENCE_USERNAME: ${{ secrets.CONFLUENCE_USERNAME }}
-          CONFLUENCE_TOKEN: ${{ secrets.CONFLUENCE_TOKEN }}
           DRY_RUN: "true"
         run: |
           cd functional-tests

--- a/.github/workflows/publish-specs-to-test-environment.yml
+++ b/.github/workflows/publish-specs-to-test-environment.yml
@@ -41,9 +41,6 @@ jobs:
 
       - name: Dry Run publish specs
         env:
-          CONFLUENCE_BASE_URL: ${{ secrets.CONFLUENCE_BASE_URL }}
-          CONFLUENCE_USERNAME: ${{ secrets.CONFLUENCE_USERNAME }}
-          CONFLUENCE_TOKEN: ${{ secrets.CONFLUENCE_TOKEN }}
           DRY_RUN: "true"
         run: |
           cd functional-tests

--- a/README.md
+++ b/README.md
@@ -120,6 +120,9 @@ spec headings).
 This is very useful e.g. **in a CI/CD pipeline the plugin can run in dry run mode on feature branches and pull
 requests.** This ensures that the Gauge specs are always in good shape to be automatically published by the CI/CD pipeline upon any push to the trunk branch (e.g. upon a successful pull request merge).
 
+The three config variables which are mandatory for actual publishing (`CONFLUENCE_BASE_URL`, `CONFLUENCE_USERNAME` and
+`CONFLUENCE_TOKEN`) do not need to be provided when doing a dry run.
+
 ___
 If the `CONFLUENCE_SPACE_KEY` is not provided, the plugin will derive the Space key to be used based on the remote Git repository URL. This convention ensures that each Git repository has its own unique Confluence space key derived from it, i.e. a one to one mapping between each Git repository and its associated one to one space.
 

--- a/functional-tests/specs/check_config_vars.spec
+++ b/functional-tests/specs/check_config_vars.spec
@@ -1,4 +1,4 @@
-# Configuration variables are required to be set
+# Configuration variables are required to be set, unless in dry run mode
 Tags: create-space-manually
 
    |config variable     |
@@ -10,6 +10,17 @@ Tags: create-space-manually
 ## The plugin fails if required configuration variables are not set
 
 * Required configuration variable <config variable> must be set
+
+
+## Configuration variables are not required to be set in dry run mode
+
+* Activate dry run mode
+
+* Initialize an empty Gauge project
+
+* Publish Confluence Documentation for the current project with no <config variable> configured and assert "did" succeed
+
+* Output contains "Dry run finished successfully"
 
 
 ________________________________________________________________________________________________

--- a/functional-tests/specs/check_config_vars.spec
+++ b/functional-tests/specs/check_config_vars.spec
@@ -16,9 +16,7 @@ Tags: create-space-manually
 
 * Activate dry run mode
 
-* Initialize an empty Gauge project
-
-* Publish Confluence Documentation for the current project with no <config variable> configured and assert "did" succeed
+* Publish Confluence Documentation with no <config variable> configured and assert "did" succeed
 
 * Output contains "Dry run finished successfully"
 

--- a/functional-tests/specs/concepts/check_config_vars.cpt
+++ b/functional-tests/specs/concepts/check_config_vars.cpt
@@ -1,8 +1,6 @@
 # Required configuration variable <configVar> must be set
 
-* Initialize an empty Gauge project
-
-* Publish Confluence Documentation for the current project with no <configVar> configured and assert "did not" succeed
+* Publish Confluence Documentation with no <configVar> configured and assert "did not" succeed
 
 * Output contains "Aborting: " <configVar> " is not set. Set it and try again."
 * Output contains "See https://github.com/agilepathway/gauge-confluence#plugin-setup"

--- a/functional-tests/specs/concepts/check_config_vars.cpt
+++ b/functional-tests/specs/concepts/check_config_vars.cpt
@@ -2,7 +2,7 @@
 
 * Initialize an empty Gauge project
 
-* Publish Confluence Documentation for the current project with no <configVar> configured
+* Publish Confluence Documentation for the current project with no <configVar> configured and assert "did not" succeed
 
 * Output contains "Aborting: " <configVar> " is not set. Set it and try again."
 * Output contains "See https://github.com/agilepathway/gauge-confluence#plugin-setup"

--- a/functional-tests/src/test/java/com/thoughtworks/gauge/test/implementation/Execution.java
+++ b/functional-tests/src/test/java/com/thoughtworks/gauge/test/implementation/Execution.java
@@ -29,8 +29,9 @@ public class Execution {
         assertOn(getCurrentProject().publishConfluenceDocumentation(), result);
     }
 
-    @Step("Publish Confluence Documentation for the current project with no <variable> configured and assert <did|did not> succeed")
-    public void publishConfluenceDocumentationForCurrentProjectWithConfigVarUnset(String configVar, String didOrDidNotSucceed) throws Exception {
+    @Step("Publish Confluence Documentation with no <variable> configured and assert <did|did not> succeed")
+    public void publishConfluenceDocumentationWithConfigVarUnset(String configVar, String didOrDidNotSucceed) throws Exception {
+        new ProjectInit().projectInit();
         boolean result = (didOrDidNotSucceed.equalsIgnoreCase("did"));
         assertOn(getCurrentProject().publishConfluenceDocumentationWithConfigVarUnset(configVar), result);
     }

--- a/functional-tests/src/test/java/com/thoughtworks/gauge/test/implementation/Execution.java
+++ b/functional-tests/src/test/java/com/thoughtworks/gauge/test/implementation/Execution.java
@@ -25,13 +25,14 @@ public class Execution {
 
     @Step("Publish Confluence Documentation for the current project and assert <did|did not> succeed")
     public void publishConfluenceDocumentationForCurrentProjectAndAssertResult(String didOrDidNotSucceed) throws Exception {
-        boolean success = (didOrDidNotSucceed.equalsIgnoreCase("did"));
-        assertOn(getCurrentProject().publishConfluenceDocumentation(), success);
+        boolean result = (didOrDidNotSucceed.equalsIgnoreCase("did"));
+        assertOn(getCurrentProject().publishConfluenceDocumentation(), result);
     }
 
-    @Step("Publish Confluence Documentation for the current project with no <variable> configured")
-    public void publishConfluenceDocumentationForCurrentProjectWithConfigVarUnset(String configVar) throws Exception {
-        assertOn(getCurrentProject().publishConfluenceDocumentationWithConfigVarUnset(configVar), false);
+    @Step("Publish Confluence Documentation for the current project with no <variable> configured and assert <did|did not> succeed")
+    public void publishConfluenceDocumentationForCurrentProjectWithConfigVarUnset(String configVar, String didOrDidNotSucceed) throws Exception {
+        boolean result = (didOrDidNotSucceed.equalsIgnoreCase("did"));
+        assertOn(getCurrentProject().publishConfluenceDocumentationWithConfigVarUnset(configVar), result);
     }
 
     @Step("Publish Confluence Documentation for two projects")

--- a/internal/confluence/api/client.go
+++ b/internal/confluence/api/client.go
@@ -20,11 +20,19 @@ type Client struct {
 
 // NewClient initialises a new Client.
 func NewClient() Client {
+	if env.GetBoolean("DRY_RUN") {
+		return dummyClient()
+	}
+
 	httpClient := http.NewClient(baseEndpoint(), username(), token())
 	goconfluenceClient, err := goconfluence.NewAPI(baseEndpoint(), username(), token())
 	util.Fatal("Error while creating Confluence API Client", err)
 
 	return Client{httpClient, goconfluenceClient}
+}
+
+func dummyClient() Client {
+	return Client{http.NewClient("", "", ""), nil}
 }
 
 // PublishPage publishes a page to Confluence as a child of the given parent page.

--- a/internal/confluence/space.go
+++ b/internal/confluence/space.go
@@ -56,7 +56,15 @@ func keyFmt(u *url.URL) string {
 	return strings.ToUpper(alphanumeric)
 }
 
+func (s *space) checkRequiredConfigVars() {
+	env.GetRequired("CONFLUENCE_BASE_URL")
+	env.GetRequired("CONFLUENCE_USERNAME")
+	env.GetRequired("CONFLUENCE_TOKEN")
+}
+
 func (s *space) setup() error { // nolint:funlen
+	s.checkRequiredConfigVars()
+
 	key, err := retrieveOrGenerateKey()
 	if err != nil {
 		return err

--- a/main.go
+++ b/main.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/agilepathway/gauge-confluence/gauge_messages"
 	"github.com/agilepathway/gauge-confluence/internal/confluence"
-	"github.com/agilepathway/gauge-confluence/internal/env"
 	"github.com/agilepathway/gauge-confluence/internal/logger"
 	"github.com/agilepathway/gauge-confluence/util"
 	"google.golang.org/grpc"
@@ -47,7 +46,6 @@ func (h *handler) stopServer() {
 
 func main() {
 	logger.Initialize(loglevel())
-	checkRequiredConfigVars()
 
 	err := os.Chdir(projectRoot)
 	util.Fatal("failed to change directory to project root.", err)
@@ -63,12 +61,6 @@ func main() {
 	gauge_messages.RegisterDocumenterServer(server, h)
 	fmt.Printf("Listening on port:%d /n", l.Addr().(*net.TCPAddr).Port)
 	server.Serve(l) //nolint:errcheck,gosec
-}
-
-func checkRequiredConfigVars() {
-	env.GetRequired("CONFLUENCE_BASE_URL")
-	env.GetRequired("CONFLUENCE_USERNAME")
-	env.GetRequired("CONFLUENCE_TOKEN")
 }
 
 // providedSpecsPaths returns the specs paths passed in

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "confluence",
-    "version": "0.16.1",
+    "version": "0.17.0",
     "name": "Confluence",
     "description": "Publishes Gauge specifications to Confluence",
     "install": {


### PR DESCRIPTION
The three config variables which are mandatory for actual publishing
(`CONFLUENCE_BASE_URL`, `CONFLUENCE_USERNAME` and `CONFLUENCE_TOKEN`) no
longer need to be provided when doing a dry run.  This is useful as it
means that anyone can run the plugin locally on their own machine in
dry run mode (by setting the config variable `DRY_RUN` to `true`) to
verify that the Gauge specs are publishable (i.e they do not have any
duplicates).