### PR TITLE
Ensure plugin Git branch logic works on GitLab CI

### DIFF
--- a/internal/git/branch_test.go
+++ b/internal/git/branch_test.go
@@ -3,6 +3,7 @@ package git
 import (
 	"errors"
 	"fmt"
+	"os"
 	"testing"
 )
 
@@ -48,5 +49,18 @@ func TestDetachedHead(t *testing.T) {
 
 	if errors.Is(err, expectedErr) {
 		t.Errorf("Unexpected error for input %v: %v", detachedHead, err)
+	}
+}
+
+func TestDiscoverCurrentBranch(t *testing.T) {
+	expected := "from-ci-commit-branch-env-var"
+	os.Setenv("CI_COMMIT_BRANCH", expected) //nolint
+
+	branchName, err := discoverCurrentBranch()
+
+	os.Unsetenv("CI_COMMIT_BRANCH") //nolint
+
+	if branchName != expected || err != nil {
+		t.Fatalf(`discoverCurrentBranch("") = %q, %v, want %s, nil`, branchName, err, expected)
 	}
 }

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "confluence",
-    "version": "0.18.0",
+    "version": "0.18.1",
     "name": "Confluence",
     "description": "Publishes Gauge specifications to Confluence",
     "install": {


### PR DESCRIPTION
This commit fixes an issue when running the plugin on GitLab CI. Prior
to this commit the plugin would report that it could not obtain the
current Git branch when running on GitLab CI. This was because GitLab 
CI runs in detached HEAD mode, meaning that the plugin's Git branch
derivation logic could not work.

(The plugin needs to derive the Git branch so that it can provide a link
from each published Gauge spec in Confluence back to the spec file's
source code in GitLab/GitHub etc.)

The fix is to look for a `CI_COMMIT_BRANCH` environment variable 
(which is automatically set by GitLab CI), and if it exists then to use 
it  as the current branch name.  If the environment variable does not 
exist (i.e. when not running on GitLab) then the logic falls back to
deriving the Git branch from the local Git files as it always has done.